### PR TITLE
Fix all files being printed on the dashboard instead of just the mp4 files

### DIFF
--- a/machinery/src/routers/http/Routes.go
+++ b/machinery/src/routers/http/Routes.go
@@ -73,7 +73,7 @@ func AddRoutes(r *gin.Engine, authMiddleware *jwt.GinJWTMiddleware, configuratio
 
 			// The total number of recordings stored in the directory.
 			recordingDirectory := "./data/recordings"
-			numberOfRecordings := utils.NumberOfFilesInDirectory(recordingDirectory)
+			numberOfRecordings := utils.NumberOfMP4sInDirectory(recordingDirectory)
 
 			// All days stored in this agent.
 			days := []string{}

--- a/machinery/src/utils/main.go
+++ b/machinery/src/utils/main.go
@@ -186,6 +186,12 @@ func NumberOfFilesInDirectory(path string) int {
 	return len(files)
 }
 
+func NumberOfMP4sInDirectory(path string) int {
+	pattern := filepath.Join(path, "*.mp4")
+	files, _ := filepath.Glob(pattern)
+	return len(files)
+}
+
 func RandStringBytesRmndr(n int) string {
 	b := make([]byte, n)
 	for i := range b {

--- a/machinery/src/utils/main.go
+++ b/machinery/src/utils/main.go
@@ -186,7 +186,7 @@ func NumberOfFilesInDirectory(path string) int {
 	return len(files)
 }
 
-// Returns the count of all files with mp4 extension in current directory
+// NumberOfMP4sInDirectory returns the count of all files with mp4 extension in current directory
 func NumberOfMP4sInDirectory(path string) int {
 	pattern := filepath.Join(path, "*.mp4")
 	files, _ := filepath.Glob(pattern)

--- a/machinery/src/utils/main.go
+++ b/machinery/src/utils/main.go
@@ -186,6 +186,7 @@ func NumberOfFilesInDirectory(path string) int {
 	return len(files)
 }
 
+// Returns the count of all files with mp4 extension in current directory
 func NumberOfMP4sInDirectory(path string) int {
 	pattern := filepath.Join(path, "*.mp4")
 	files, _ := filepath.Glob(pattern)


### PR DESCRIPTION
Implemented new `util` function, which gets count of only `.mp4` extension.

This solves the problem of folders being counted as recordings on dashboard.