### PR TITLE
Alpine+go combination doesn't resolve DNS correctly under docker comp…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN cat /go/src/github.com/kerberos-io/agent/machinery/version
 
 RUN cd /go/src/github.com/kerberos-io/agent/machinery && \
 	go mod download && \
-	go build -tags timetzdata --ldflags '-s -w -extldflags "-static -latomic"' main.go && \
+	go build -tags timetzdata,netgo --ldflags '-s -w -extldflags "-static -latomic"' main.go && \
 	mkdir -p /agent && \
 	mv main /agent && \
 	mv version /agent && \


### PR DESCRIPTION
After some investigation where docker run would work but docker compose would not we have found out that combination of alpine + golang sometimes does not correctly resolve DNS requests.

This is really hard to debug because everything else works properly in the running container.

Solution is to force golang to use another resolver system by adding netgo tag in the build process or at least that's how I understand what this does. :)