### PR TITLE
Verify if device is nil, if so do not proceed (avoic panic)

### DIFF
--- a/machinery/src/onvif/main.go
+++ b/machinery/src/onvif/main.go
@@ -986,6 +986,10 @@ func CreatePullPointSubscription(dev *onvif.Device) (string, error) {
 	// For the time being we are just interested in the digital inputs and outputs, therefore
 	// we have set the topic to the followin filter.
 	terminate := xsd.String("PT60S")
+	if dev == nil {
+		return pullPointAdress, errors.New("dev is nil, ONVIF was not able to connect to the device")
+	}
+
 	resp, err := dev.CallMethod(event.CreatePullPointSubscription{
 		InitialTerminationTime: &terminate,
 


### PR DESCRIPTION
This pull request includes an important change to the `machinery/src/onvif/main.go` file to improve error handling in the `CreatePullPointSubscription` function. The most significant change is the addition of a check to ensure the `dev` parameter is not nil before proceeding with the method call.

Error handling improvement:

* [`machinery/src/onvif/main.go`](diffhunk://#diff-ab95c734940c4ce070a84bdd341146ad475c716710da9aedfcbf539c24dd34c7R989-R992): Added a nil check for the `dev` parameter in the `CreatePullPointSubscription` function to return an error if `dev` is nil, preventing potential runtime errors when the device is not connected.