### PR TITLE
Initiate decoders globally

### DIFF
--- a/machinery/src/capture/gortsplib.go
+++ b/machinery/src/capture/gortsplib.go
@@ -83,6 +83,25 @@ type Golibrtsp struct {
 	Streams []packets.Stream
 }
 
+// Init function
+var H264FrameDecoder *Decoder
+var H265FrameDecoder *Decoder
+
+func init() {
+	var err error
+	// setup H264 -> raw frames decoder
+	H264FrameDecoder, err = newDecoder("H264")
+	if err != nil {
+		log.Log.Error("capture.golibrtsp.init(): " + err.Error())
+	}
+
+	// setup H265 -> raw frames decoder
+	H265FrameDecoder, err = newDecoder("H265")
+	if err != nil {
+		log.Log.Error("capture.golibrtsp.Connect(H265): " + err.Error())
+	}
+}
+
 // Connect to the RTSP server.
 func (g *Golibrtsp) Connect(ctx context.Context) (err error) {
 
@@ -171,13 +190,7 @@ func (g *Golibrtsp) Connect(ctx context.Context) (err error) {
 				log.Log.Error("capture.golibrtsp.Connect(H264): " + err.Error())
 			}
 			g.VideoH264Decoder = rtpDec
-
-			// setup H264 -> raw frames decoder
-			frameDec, err := newDecoder("H264")
-			if err != nil {
-				log.Log.Error("capture.golibrtsp.Connect(H264): " + err.Error())
-			}
-			g.VideoH264FrameDecoder = frameDec
+			g.VideoH264FrameDecoder = H264FrameDecoder
 		}
 	}
 
@@ -227,12 +240,7 @@ func (g *Golibrtsp) Connect(ctx context.Context) (err error) {
 			}
 			g.VideoH265Decoder = rtpDec
 
-			// setup H265 -> raw frames decoder
-			frameDec, err := newDecoder("H265")
-			if err != nil {
-				log.Log.Error("capture.golibrtsp.Connect(H265): " + err.Error())
-			}
-			g.VideoH265FrameDecoder = frameDec
+			g.VideoH265FrameDecoder = H265FrameDecoder
 		}
 	}
 
@@ -882,12 +890,15 @@ func (g *Golibrtsp) GetAudioStreams() ([]packets.Stream, error) {
 func (g *Golibrtsp) Close() error {
 	// Close the demuxer.
 	g.Client.Close()
-	if g.VideoH264Decoder != nil {
-		g.VideoH264FrameDecoder.Close()
-	}
-	if g.VideoH265FrameDecoder != nil {
-		g.VideoH265FrameDecoder.Close()
-	}
+
+	// We will have created the decoders globally, so we don't need to close them here.
+
+	//if g.VideoH264Decoder != nil {
+	//	g.VideoH264FrameDecoder.Close()
+	//}
+	//if g.VideoH265FrameDecoder != nil {
+	//	g.VideoH265FrameDecoder.Close()
+	//}
 	return nil
 }
 

--- a/machinery/src/capture/gortsplib.go
+++ b/machinery/src/capture/gortsplib.go
@@ -98,7 +98,7 @@ func init() {
 	// setup H265 -> raw frames decoder
 	H265FrameDecoder, err = newDecoder("H265")
 	if err != nil {
-		log.Log.Error("capture.golibrtsp.Connect(H265): " + err.Error())
+		log.Log.Error("capture.golibrtsp.init(): " + err.Error())
 	}
 }
 


### PR DESCRIPTION
## Description

### Pull Request Title: Initiate decoders globally

### Description:

#### Motivation:
The motivation behind this change is to streamline the initialization and management of decoders within the `Golibrtsp` structure. By initiating the H264 and H265 frame decoders globally, we aim to enhance the efficiency and maintainability of the code. This change also reduces redundancy and potential errors related to multiple initializations and closures of the same decoders.

#### Changes:
1. **Global Initialization of Decoders:**
   - Introduced global variables `H264FrameDecoder` and `H265FrameDecoder`.
   - Added an `init` function to initialize these decoders at the start of the program.
   - Error handling for decoder initialization is performed within the `init` function, logging any issues encountered.

2. **Refactor `Connect` Method:**
   - Updated the `Connect` method to use the globally initialized decoders instead of creating new instances each time a connection is made.
   - Removed redundant decoder initialization code from the `Connect` method.

3. **Update `Close` Method:**
   - Commented out the closure of decoders in the `Close` method, as they are now managed globally and should not be closed individually.

#### Benefits:
- **Efficiency:** By initializing the decoders globally, we avoid multiple allocations and deallocations, which can be resource-intensive.
- **Maintainability:** Centralizing the initialization logic simplifies the codebase, making it easier to manage and debug.
- **Error Handling:** Initializing decoders globally allows for centralized error handling, ensuring any issues are logged immediately during startup.

This change improves the overall stability and performance of the project by ensuring decoders are correctly managed and reducing the complexity of the `Golibrtsp` implementation.