### PR TITLE
Stable release onvif v1.0.0

### DIFF
--- a/machinery/go.mod
+++ b/machinery/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/kellydunn/golang-geo v0.7.0
 	github.com/kerberos-io/joy4 v1.0.64
-	github.com/kerberos-io/onvif v0.0.17
+	github.com/kerberos-io/onvif v1.0.0
 	github.com/minio/minio-go/v6 v6.0.57
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pion/rtp v1.8.10

--- a/machinery/go.sum
+++ b/machinery/go.sum
@@ -298,8 +298,8 @@ github.com/kellydunn/golang-geo v0.7.0 h1:A5j0/BvNgGwY6Yb6inXQxzYwlPHc6WVZR+Mrar
 github.com/kellydunn/golang-geo v0.7.0/go.mod h1:YYlQPJ+DPEzrHx8kT3oPHC/NjyvCCXE+IuKGKdrjrcU=
 github.com/kerberos-io/joy4 v1.0.64 h1:gTUSotHSOhp9mNqEecgq88tQHvpj7TjmrvPUsPm0idg=
 github.com/kerberos-io/joy4 v1.0.64/go.mod h1:nZp4AjvKvTOXRrmDyAIOw+Da+JA5OcSo/JundGfOlFU=
-github.com/kerberos-io/onvif v0.0.17 h1:BK91WK+cO4lPvhVTh0dPtALRxjGIlFdXiA3O9tvq2UQ=
-github.com/kerberos-io/onvif v0.0.17/go.mod h1:P1kUcCfeotJSlL1jwGseH6NSnCwWiuJLl3gAzafnLbA=
+github.com/kerberos-io/onvif v1.0.0 h1:pLJrK6skPkK+5Bj4XfqHUkQ2I+p5pwELnp+kQTJWXiQ=
+github.com/kerberos-io/onvif v1.0.0/go.mod h1:P1kUcCfeotJSlL1jwGseH6NSnCwWiuJLl3gAzafnLbA=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.1 h1:NE3C767s2ak2bweCZo3+rdP4U/HoyVXLv/X9f2gPS5g=


### PR DESCRIPTION
## Description

### Pull Request: Stable release onvif v1.0.0

#### Motivation

The primary motivation behind this change is to upgrade the `github.com/kerberos-io/onvif` dependency from version `v0.0.17` to the stable release `v1.0.0`. This upgrade ensures that our project benefits from all the improvements, bug fixes, and new features introduced in the stable version.

#### Why It Improves the Project

1. **Stability**: Moving to a stable release (`v1.0.0`) from a pre-release (`v0.0.17`) reduces the risk of encountering breaking changes and unanticipated issues. The stable release indicates a mature and well-tested library.
   
2. **New Features and Enhancements**: The stable release is likely to include new features and enhancements that were not present in the earlier version, providing more functionality and better performance.

3. **Bug Fixes**: Upgrading to the latest version includes all the bug fixes made since the `v0.0.17` release, leading to a more reliable and robust codebase.

4. **Community and Support**: Using a stable release often means better community support and more resources for troubleshooting and development, as more users and developers adopt the stable version.

By incorporating these updates, the project aligns itself with the latest standards and practices, ensuring continued stability and functionality.