### PR TITLE
Fix/Remote config / region not properly calculated

### DIFF
--- a/machinery/src/routers/mqtt/main.go
+++ b/machinery/src/routers/mqtt/main.go
@@ -391,7 +391,8 @@ func HandleRequestConfig(mqttClient mqtt.Client, hubKey string, payload models.P
 
 			// We need a fix for the width and height if a substream.
 			// The ROI requires the width and height of the sub stream.
-			if configuration.Config.Capture.IPCamera.SubRTSP != "" {
+			if configuration.Config.Capture.IPCamera.SubRTSP != "" &&
+				configuration.Config.Capture.IPCamera.SubRTSP != configuration.Config.Capture.IPCamera.RTSP {
 				deepCopy.Capture.IPCamera.Width = configuration.Config.Capture.IPCamera.SubWidth
 				deepCopy.Capture.IPCamera.Height = configuration.Config.Capture.IPCamera.SubHeight
 			}


### PR DESCRIPTION
## Description

### Pull Request Description

**Title**: Fix/Remote config / region not properly calculated

**Motivation and Context:**
The remote configuration logic for IP camera streams was not correctly handling cases where the main RTSP stream and the sub RTSP stream were the same. This caused incorrect width and height calculations for the substream, which could lead to issues in the region of interest (ROI) processing.

**Changes:**
- Updated the condition to check if the sub RTSP stream is not only non-empty but also different from the main RTSP stream before applying width and height adjustments.
- This change ensures that the width and height adjustments for the substream are only applied when the sub RTSP stream is distinct from the main RTSP stream, thereby preventing incorrect calculations.

**Why it improves the project:**
This fix improves the project by ensuring accurate configuration of IP camera streams, which is crucial for correct ROI processing. By preventing erroneous width and height adjustments, it enhances the reliability and accuracy of the remote configuration, leading to better overall performance and fewer bugs related to stream handling.