### PR TITLE
Fix/ Increase channel buffer sizes for communication handling

### DIFF
--- a/machinery/src/components/Kerberos.go
+++ b/machinery/src/components/Kerberos.go
@@ -254,7 +254,7 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	}
 
 	// Handle livestream HD (high resolution over WEBRTC)
-	communication.HandleLiveHDHandshake = make(chan models.RequestHDStreamPayload, 1)
+	communication.HandleLiveHDHandshake = make(chan models.RequestHDStreamPayload, 10)
 	if subStreamEnabled {
 		livestreamHDCursor := subQueue.Latest()
 		go cloud.HandleLiveStreamHD(livestreamHDCursor, configuration, communication, mqttClient, rtspSubClient)
@@ -267,7 +267,7 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	go capture.HandleRecordStream(queue, configDirectory, configuration, communication, rtspClient)
 
 	// Handle processing of motion
-	communication.HandleMotion = make(chan models.MotionDataPartial, 1)
+	communication.HandleMotion = make(chan models.MotionDataPartial, 10)
 	if subStreamEnabled {
 		motionCursor := subQueue.Latest()
 		go computervision.ProcessMotion(motionCursor, configuration, communication, mqttClient, rtspSubClient)
@@ -289,10 +289,10 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	go cloud.HandleUpload(configDirectory, configuration, communication)
 
 	// Handle ONVIF actions
-	communication.HandleONVIF = make(chan models.OnvifAction, 1)
+	communication.HandleONVIF = make(chan models.OnvifAction, 10)
 	go onvif.HandleONVIFActions(configuration, communication)
 
-	communication.HandleAudio = make(chan models.AudioDataPartial, 1)
+	communication.HandleAudio = make(chan models.AudioDataPartial, 10)
 	if rtspBackChannelClient.HasBackChannel {
 		communication.HasBackChannel = true
 		go WriteAudioToBackchannel(communication, rtspBackChannelClient)


### PR DESCRIPTION
## Description

### Pull Request Title: Fix/ Increase channel buffer sizes for communication handling

### Description:

#### Motivation:
The current buffer sizes for various communication channels in the Kerberos component are set to 1. This small buffer size can lead to bottlenecks and inefficiencies in handling high-frequency data streams, potentially causing delays and dropped messages. Increasing the buffer sizes will enhance the system's capability to manage bursts of data more effectively without immediate processing requirements.

#### Changes:
- Increased buffer size from 1 to 10 for the following communication channels:
  - `HandleLiveHDHandshake`
  - `HandleMotion`
  - `HandleONVIF`
  - `HandleAudio`

#### Benefits:
1. **Improved Performance:** Larger buffers will reduce the risk of blocking operations and improve the system's ability to handle high-frequency data streams efficiently.
2. **Reduced Data Loss:** Increasing the buffer size minimizes the chances of dropped messages, ensuring more reliable data processing and communication.
3. **Enhanced Responsiveness:** With larger buffers, the system can better manage bursts of activity, leading to more responsive and stable operation.

Overall, these changes will contribute to a more robust and efficient communication handling within the Kerberos component, improving the project's reliability and performance.