### PR TITLE
Make KStorage fields optional in JSON and BSON serialization

### DIFF
--- a/machinery/src/models/Config.go
+++ b/machinery/src/models/Config.go
@@ -153,12 +153,12 @@ type S3 struct {
 // KStorage contains the credentials of the Kerberos Storage/Kerberos Cloud instance.
 // By defining KStorage you can make your recordings available in the cloud, at a centrel place.
 type KStorage struct {
-	URI             string `json:"uri" bson:"uri"`
-	CloudKey        string `json:"cloud_key" bson:"cloud_key"` /* old way, remove this */
-	AccessKey       string `json:"access_key" bson:"access_key"`
-	SecretAccessKey string `json:"secret_access_key" bson:"secret_access_key"`
-	Provider        string `json:"provider" bson:"provider"`
-	Directory       string `json:"directory" bson:"directory"`
+	URI             string `json:"uri,omitempty" bson:"uri,omitempty"`
+	CloudKey        string `json:"cloud_key,omitempty" bson:"cloud_key,omitempty"` /* old way, remove this */
+	AccessKey       string `json:"access_key,omitempty" bson:"access_key,omitempty"`
+	SecretAccessKey string `json:"secret_access_key,omitempty" bson:"secret_access_key,omitempty"`
+	Provider        string `json:"provider,omitempty" bson:"provider,omitempty"`
+	Directory       string `json:"directory,omitempty" bson:"directory,omitempty"`
 }
 
 // Dropbox integration


### PR DESCRIPTION
## Description

### Pull Request Description

**Title**: Make KStorage fields optional in JSON and BSON serialization

**Motivation**:
Currently, all fields in the `KStorage` struct are mandatory during JSON and BSON serialization. This requirement can lead to unnecessary data being passed around and stored, especially when certain fields are not always needed. Making these fields optional improves the flexibility and usability of the `KStorage` struct.

**Changes**:
1. Updated the `KStorage` struct in `machinery/src/models/Config.go` to include `omitempty` tags for all fields in JSON and BSON serialization.
   ```go
   type KStorage struct {
       URI             string `json:"uri,omitempty" bson:"uri,omitempty"`
       CloudKey        string `json:"cloud_key,omitempty" bson:"cloud_key,omitempty"` /* old way, remove this */
       AccessKey       string `json:"access_key,omitempty" bson:"access_key,omitempty"`
       SecretAccessKey string `json:"secret_access_key,omitempty" bson:"secret_access_key,omitempty"`
       Provider        string `json:"provider,omitempty" bson:"provider,omitempty"`
       Directory       string `json:"directory,omitempty" bson:"directory,omitempty"`
   }
   ```

**Why It Improves the Project**:
- **Flexibility**: Allows partial updates and storage of `KStorage` objects without requiring all fields, thus accommodating various use cases where only specific fields are relevant.
- **Efficiency**: Reduces payload size during serialization, leading to potential performance improvements in data transfer and storage.
- **Usability**: Simplifies code that interacts with `KStorage` by not mandating the presence of all fields, making the system more user-friendly and adaptable.

This change enhances the overall robustness and adaptability of the project by ensuring that the `KStorage` struct can be used more dynamically and efficiently.