### PR TITLE
Add support for secondary Kerberos Vault settings in configuration

### DIFF
--- a/machinery/src/config/main.go
+++ b/machinery/src/config/main.go
@@ -135,6 +135,12 @@ func OpenConfig(configDirectory string, configuration *models.Configuration) {
 		conjungo.Merge(&kerberosvault, configuration.CustomConfig.KStorage, opts)
 		configuration.Config.KStorage = &kerberosvault
 
+		// Merge Secondary Kerberos Vault settings
+		var kerberosvaultSecondary models.KStorage
+		conjungo.Merge(&kerberosvaultSecondary, configuration.GlobalConfig.KStorageSecondary, opts)
+		conjungo.Merge(&kerberosvaultSecondary, configuration.CustomConfig.KStorageSecondary, opts)
+		configuration.Config.KStorageSecondary = &kerberosvaultSecondary
+
 		// Merge Kerberos S3 settings
 		var s3 models.S3
 		conjungo.Merge(&s3, configuration.GlobalConfig.S3, opts)


### PR DESCRIPTION
## Description

### Pull Request Title: Add support for secondary Kerberos Vault settings in configuration

### Description:

#### Motivation:
The primary motivation behind this change is to enhance the flexibility and robustness of the configuration system by adding support for secondary Kerberos Vault settings. This will allow users to define and use an additional set of Kerberos Vault configurations, which can be crucial for environments that require multiple vaults for redundancy, load balancing, or different operational requirements.

#### Improvements:
1. **Redundancy and Reliability**: By supporting secondary Kerberos Vault settings, the system can now fall back to secondary configurations in case the primary settings fail, thereby improving the overall reliability and fault tolerance of the application.
2. **Enhanced Flexibility**: Users can now specify multiple Kerberos Vault configurations, catering to complex deployment scenarios where different vaults might be needed for various purposes.
3. **Seamless Integration**: The changes merge secondary Kerberos Vault settings seamlessly into the existing configuration structure, ensuring backward compatibility and minimal disruption to current users.

### Changes:
1. **Configuration Merging**:
   - Added code to merge secondary Kerberos Vault settings from both global and custom configurations using `conjungo.Merge`.
   - Ensured that the merged secondary settings are correctly assigned to `configuration.Config.KStorageSecondary`.

2. **Code Modifications**:
   - Updated the `OpenConfig` function in `machinery/src/config/main.go` to include the merging logic for `KStorageSecondary`.

By implementing these changes, we are confident that the project will benefit from improved configuration management capabilities, thereby enhancing its robustness and adaptability to various operational needs.