### PR TITLE
Update base image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM kerberos/base:af04230 AS build-machinery
+FROM kerberos/base:70ec57e AS build-machinery
 LABEL AUTHOR=Kerberos.io
 
 ENV GOROOT=/usr/local/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 
-FROM kerberos/base:70ec57e AS build-machinery
+ARG BASE_IMAGE_VERSION=70ec57e
+FROM kerberos/base:${BASE_IMAGE_VERSION} AS build-machinery
 LABEL AUTHOR=Kerberos.io
 
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
## Description

### Pull Request Title: Update base image version in Dockerfile

### Description:

#### Motivation:
The primary motivation behind this change is to ensure that our Docker image uses the latest base image version. Updating the base image version can bring several improvements including security patches, performance enhancements, and updated dependencies. This contributes to the overall stability and security of our project.

#### Changes:
1. Introduced a new build argument `BASE_IMAGE_VERSION` in the Dockerfile.
2. Updated the `FROM` instruction to use the `BASE_IMAGE_VERSION` argument, making it easier to update the base image version in the future.
3. Set the `BASE_IMAGE_VERSION` to `70ec57e`, replacing the old version `af04230`.

#### Benefits:
- **Security**: Using the latest base image version ensures that we incorporate all recent security patches, reducing vulnerabilities.
- **Maintainability**: Introducing the `BASE_IMAGE_VERSION` argument makes it simpler to update the base image version in the future, enhancing maintainability.
- **Stability**: By using an updated base image, we leverage the latest stability and performance improvements, ensuring a more robust application.

This change is a proactive measure to keep our project up-to-date with the latest improvements and best practices in containerization.