### PR TITLE
Update Docker build workflow to use input tag for image naming

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,13 +39,14 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Run Buildx
-        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}} --push .
+        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}} --push .
       - name: Create new and append to manifest
-        run: docker buildx imagetools create -t $REPO:${{ github.ref_name }} $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}}
+        run: docker buildx imagetools create -t $REPO:${{ github.event.inputs.tag || github.ref_name }} $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}}
       - name: Create new and append to manifest latest
-        run: docker buildx imagetools create -t $REPO:latest $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}}
+        run: docker buildx imagetools create -t $REPO:latest $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}}
+        if: github.event.inputs.tag == 'test'
       - name: Run Buildx with output
-        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-$(echo ${{matrix.architecture}} | tr / -)-${{github.ref_name}} --output type=tar,dest=output-${{matrix.architecture}}.tar .
+        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-$(echo ${{matrix.architecture}} | tr / -)-${{github.event.inputs.tag || github.ref_name}} --output type=tar,dest=output-${{matrix.architecture}}.tar .
       - name: Strip binary
         run: mkdir -p output/ && tar -xf output-${{matrix.architecture}}.tar -C output && rm output-${{matrix.architecture}}.tar && cd output/ && tar -cf ../agent-${{matrix.architecture}}.tar -C home/agent . && rm -rf output
       - name: Create a release
@@ -53,8 +54,8 @@ jobs:
         with:
           latest: true
           allowUpdates: true
-          name: ${{ github.ref_name }}
-          tag: ${{ github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag: ${{ github.event.inputs.tag || github.ref_name }}
           generateReleaseNotes: false
           omitBodyDuringUpdate: true
           artifacts: "agent-${{matrix.architecture}}.tar"
@@ -97,13 +98,14 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Run Buildx
-        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}} --push .
+        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}} --push .
       - name: Create new and append to manifest
-        run: docker buildx imagetools create --append -t $REPO:${{ github.ref_name }} $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}}
+        run: docker buildx imagetools create --append -t $REPO:${{ github.event.inputs.tag || github.ref_name }} $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}}
       - name: Create new and append to manifest latest
-        run: docker buildx imagetools create --append -t $REPO:latest $REPO-arch:arch-${{matrix.architecture}}-${{github.ref_name}}
+        run: docker buildx imagetools create --append -t $REPO:latest $REPO-arch:arch-${{matrix.architecture}}-${{github.event.inputs.tag || github.ref_name}}
+        if: github.event.inputs.tag == 'test'
       - name: Run Buildx with output
-        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-$(echo ${{matrix.architecture}} | tr / -)-${{github.ref_name}} --output type=tar,dest=output-${{matrix.architecture}}.tar .
+        run: docker buildx build --platform linux/$(echo ${{matrix.architecture}} | tr - /) -t $REPO-arch:arch-$(echo ${{matrix.architecture}} | tr / -)-${{github.event.inputs.tag || github.ref_name}} --output type=tar,dest=output-${{matrix.architecture}}.tar .
       - name: Strip binary
         run: mkdir -p output/ && tar -xf output-${{matrix.architecture}}.tar -C output && rm output-${{matrix.architecture}}.tar && cd output/ && tar -cf ../agent-${{matrix.architecture}}.tar -C home/agent . && rm -rf output
       - name: Create a release
@@ -111,8 +113,8 @@ jobs:
         with:
           latest: true
           allowUpdates: true
-          name: ${{ github.ref_name }}
-          tag: ${{ github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag: ${{ github.event.inputs.tag || github.ref_name }}
           generateReleaseNotes: false
           omitBodyDuringUpdate: true
           artifacts: "agent-${{matrix.architecture}}.tar"


### PR DESCRIPTION
## Description

### Pull Request Title: Update Docker Build Workflow to Use Input Tag for Image Naming

### Description:

#### Motivation:
The current Docker build workflow in our CI pipeline uses the `github.ref_name` for naming Docker images and tags. This approach limits flexibility, especially when we want to trigger builds with custom tags, such as for testing or pre-release versions. By enabling the use of an input tag for image naming, we can streamline our workflow and better support various CI/CD scenarios.

#### Changes:
1. **Modified `.github/workflows/docker.yml`**:
   - Updated the `docker buildx build` command to use `${{ github.event.inputs.tag || github.ref_name }}` for the image tag instead of just `${{ github.ref_name }}`.
   - Applied the same change to the `docker buildx imagetools create` commands to ensure consistency in image naming.
   - Added a conditional `if: github.event.inputs.tag == 'test'` to the `docker buildx imagetools create -t $REPO:latest` step to selectively apply the 'latest' tag during tests.
   - Updated the release creation steps to use `${{ github.event.inputs.tag || github.ref_name }}` for the release name and tag.

#### Benefits:
- **Enhanced Flexibility**: Allows for custom tagging of Docker images, making it easier to manage versions and environments (e.g., testing, staging, production).
- **Improved CI/CD Workflow**: Streamlines the process of tagging and releasing Docker images, reducing manual intervention and potential errors.
- **Consistency**: Ensures that all steps in the workflow use the same tag, whether it's a custom input tag or the default `github.ref_name`.

This change significantly improves our ability to manage Docker images within our CI pipeline, enabling more versatile and robust deployment practices.