### PR TITLE
fix/add audio codec handling in HandleRecordStream function

### DIFF
--- a/machinery/src/capture/main.go
+++ b/machinery/src/capture/main.go
@@ -78,6 +78,19 @@ func HandleRecordStream(queue *packets.Queue, configDirectory string, configurat
 		// For continuous and motion based recording we will use a single file.
 		var file *os.File
 
+		// Get Video and Audio streams.
+		//videoSteams, _ := rtspClient.GetVideoStreams()
+		audioStreams, _ := rtspClient.GetAudioStreams()
+		// Check if we have AAC audio codec.
+		audioCodec := ""
+		for _, stream := range audioStreams {
+			if stream.Name == "AAC" {
+				audioCodec = stream.Name
+			} else if stream.Name == "PCM_MULAW" {
+				audioCodec = stream.Name
+			}
+		}
+
 		// Check if continuous recording.
 		if config.Capture.Continuous == "true" {
 
@@ -237,7 +250,9 @@ func HandleRecordStream(queue *packets.Queue, configDirectory string, configurat
 							videoTrack = myMuxer.AddVideoTrack(mp4.MP4_CODEC_H265, widthOption, heightOption)
 						}
 						// For an MP4 container, AAC is the only audio codec supported.
-						audioTrack = myMuxer.AddAudioTrack(mp4.MP4_CODEC_AAC)
+						if audioCodec == "AAC" {
+							audioTrack = myMuxer.AddAudioTrack(mp4.MP4_CODEC_AAC)
+						}
 					} else {
 						log.Log.Error("capture.main.HandleRecordStream(continuous): " + err.Error())
 					}
@@ -405,7 +420,10 @@ func HandleRecordStream(queue *packets.Queue, configDirectory string, configurat
 					}
 				}
 				// For an MP4 container, AAC is the only audio codec supported.
-				audioTrack = myMuxer.AddAudioTrack(mp4.MP4_CODEC_AAC)
+				if audioCodec == "AAC" {
+					audioTrack = myMuxer.AddAudioTrack(mp4.MP4_CODEC_AAC)
+				}
+
 				start := false
 
 				// Get as much packets we need.


### PR DESCRIPTION
## Description

### Pull Request Title: fix/add audio codec handling in HandleRecordStream function

### Description:

#### Motivation:
The `HandleRecordStream` function lacked proper handling for different audio codecs, specifically AAC and PCM_MULAW. This limitation caused potential issues when processing streams with unsupported audio codecs, leading to potential failures or suboptimal performance.

#### Changes Introduced:
1. **Audio Stream Handling:**
   - Added functionality to retrieve audio streams from the RTSP client.
   - Implemented logic to check for the presence of AAC and PCM_MULAW audio codecs.
   - Stored the detected audio codec in the `audioCodec` variable.

2. **Conditional Audio Track Addition:**
   - Updated the logic to add audio tracks to the MP4 muxer conditionally based on the detected audio codec.
   - Ensured that only AAC audio codec is added to the MP4 container, as it is the only supported audio codec for MP4.

#### Benefits:
- **Enhanced Compatibility:** The updated function now properly handles streams with multiple audio codecs, improving compatibility and robustness.
- **Error Prevention:** By conditionally adding audio tracks based on supported codecs, the changes prevent potential errors and ensure smoother operation.
- **Future-Proofing:** This change lays the groundwork for supporting additional audio codecs in the future, making the system more extensible.

These changes collectively improve the reliability and functionality of the `HandleRecordStream` function, ensuring that it can handle a wider range of audio streams effectively.