### PR TITLE
WIP: Add ONVIF motion detection support and subscription handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN /dist/agent/main version
 ###############################################
 # Build Bento4 -> we want fragmented mp4 files
 
-ENV BENTO4_VERSION 1.6.0-641
+ENV BENTO4_VERSION=1.6.0-641
 RUN cd /tmp && git clone https://github.com/axiomatic-systems/Bento4 && cd Bento4 && \
 	git checkout tags/v${BENTO4_VERSION} && \
 	cd Build && \

--- a/machinery/src/cloud/Cloud.go
+++ b/machinery/src/cloud/Cloud.go
@@ -28,7 +28,11 @@ import (
 	"github.com/kerberos-io/agent/machinery/src/packets"
 	"github.com/kerberos-io/agent/machinery/src/utils"
 	"github.com/kerberos-io/agent/machinery/src/webrtc"
+	xsd "github.com/kerberos-io/onvif/xsd"
 )
+
+var topicKinds = xsd.String("tns1:Device/Trigger//.") // -> This works for Avigilon, Hanwa, Hikvision
+// var topicKinds = xsd.String("//.") // -> This works for Axis, but throws other errors.
 
 func PendingUpload(configDirectory string) {
 	ff, err := utils.ReadDirectory(configDirectory + "/data/cloud/")
@@ -239,7 +243,7 @@ func HandleHeartBeat(configuration *models.Configuration, communication *models.
 		cameraConfiguration := configuration.Config.Capture.IPCamera
 		device, _, err := onvif.ConnectToOnvifDevice(&cameraConfiguration)
 		if err != nil {
-			pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device)
+			pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device, topicKinds)
 			if err != nil {
 				log.Log.Error("cloud.HandleHeartBeat(): error while creating pull point subscription: " + err.Error())
 			}
@@ -306,7 +310,7 @@ loop:
 				//      - In this scenario we are creating a new subscription to retrieve the initial (current) state of the inputs and outputs.
 
 				// Get a new pull point address, to get the initiatal state of the inputs and outputs.
-				pullPointAddressInitialState, err := onvif.CreatePullPointSubscription(device)
+				pullPointAddressInitialState, err := onvif.CreatePullPointSubscription(device, topicKinds)
 				if err != nil {
 					log.Log.Error("cloud.HandleHeartBeat(): error while creating pull point subscription: " + err.Error())
 				}
@@ -344,7 +348,7 @@ loop:
 					} else if err != nil {
 						log.Log.Error("cloud.HandleHeartBeat(): error while getting events: " + err.Error())
 						onvifEventsList = []byte("[]")
-						pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device)
+						pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device, topicKinds)
 						if err != nil {
 							log.Log.Error("cloud.HandleHeartBeat(): error while creating pull point subscription: " + err.Error())
 						}
@@ -354,7 +358,7 @@ loop:
 					}
 				} else {
 					log.Log.Debug("cloud.HandleHeartBeat(): no pull point address found.")
-					pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device)
+					pullPointAddressLoopState, err = onvif.CreatePullPointSubscription(device, topicKinds)
 					if err != nil {
 						log.Log.Error("cloud.HandleHeartBeat(): error while creating pull point subscription: " + err.Error())
 					}

--- a/machinery/src/computervision/main.go
+++ b/machinery/src/computervision/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kerberos-io/agent/machinery/src/log"
 	"github.com/kerberos-io/agent/machinery/src/models"
 	"github.com/kerberos-io/agent/machinery/src/packets"
+	"github.com/kerberos-io/agent/machinery/src/onvif"
 )
 
 func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Configuration, communication *models.Communication, mqttClient mqtt.Client, rtspClient capture.RTSPClient) {
@@ -31,6 +32,16 @@ func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Conf
 	if config.Capture.Continuous == "true" {
 
 		log.Log.Info("computervision.main.ProcessMotion(): you've enabled continuous recording, so no motion detection required.")
+
+	} else if config.Capture.MotionONVIF == "true" {
+
+		log.Log.Info("computervision.main.ProcessMotion(): ONVIF motion detected is enabled, so creating subscription to ONVIF motion events.")
+
+		err := onvif.ProcessONVIFMotion(configuration, communication)
+
+		if err != nil {
+			log.Log.Error("computervision.main.ProcessMotion(): ONVIF motion detected failed: " + err.Error())
+		}
 
 	} else {
 

--- a/machinery/src/config/main.go
+++ b/machinery/src/config/main.go
@@ -266,6 +266,9 @@ func OverrideWithEnvironmentVariables(configuration *models.Configuration) {
 			case "AGENT_CAPTURE_MOTION":
 				configuration.Config.Capture.Motion = value
 				break
+			case "AGENT_CAPTURE_MOTION_ONVIF":
+				configuration.Config.Capture.MotionONVIF = value
+				break
 			case "AGENT_CAPTURE_SNAPSHOTS":
 				configuration.Config.Capture.Snapshots = value
 				break

--- a/machinery/src/models/Communication.go
+++ b/machinery/src/models/Communication.go
@@ -25,6 +25,7 @@ type Communication struct {
 	HandleAudio           chan AudioDataPartial
 	HandleUpload          chan string
 	HandleHeartBeat       chan string
+	ProcessONVIFMotion    chan string
 	HandleLiveSD          chan int64
 	HandleLiveHDKeepalive chan string
 	HandleLiveHDHandshake chan RequestHDStreamPayload

--- a/machinery/src/models/Config.go
+++ b/machinery/src/models/Config.go
@@ -60,6 +60,7 @@ type Capture struct {
 	Recording             string      `json:"recording,omitempty"`
 	Snapshots             string      `json:"snapshots,omitempty"`
 	Motion                string      `json:"motion,omitempty"`
+	MotionONVIF           string      `json:"motiononvif,omitempty"`
 	Liveview              string      `json:"liveview,omitempty"`
 	Continuous            string      `json:"continuous,omitempty"`
 	PostRecording         int64       `json:"postrecording"`


### PR DESCRIPTION
As discussed in #173 current agent doesn't support onvif motion detection.

This PR adds a function that creates an ONVIF subscription and listens for new ONVIF events. If a message with the following content is received:
```
<tt:Data>
	<tt:SimpleItem Value="true" Name="IsMotion"/>
</tt:Data>
```
it should start recording. The recording should be stopped once the same message (with `false`) is received again:
```
<tt:Data>
	<tt:SimpleItem Value="false" Name="IsMotion"/>
</tt:Data>
```
Changes Overview:
* Make the `topicKinds` in the `CreatePullPointSubscription` function configurable.
* Add a new config option `AGENT_CAPTURE_MOTION_ONVIF` that will disable internal motion detection and use ONVIF events instead.
* Add functions for retrieving, parsing, and processing ONVIF motion messages.

TODO:
* [ ] Correctly handle start and stop recording
* [ ] Update the UI
* [ ] Handle configuration change/reload
* [ ] Update the documentation
* [ ] Feature is thoroughly tested