### PR TITLE
fix/continue-on-wrong-start-time

### DIFF
--- a/machinery/src/capture/main.go
+++ b/machinery/src/capture/main.go
@@ -448,6 +448,12 @@ func HandleRecordStream(queue *packets.Queue, configDirectory string, configurat
 					startRecording = lastRecordingTime
 				}
 
+				// If startRecording is 0, we will continue as it might be we are in a state of restarting the agent.
+				if startRecording == 0 {
+					log.Log.Info("capture.main.HandleRecordStream(motiondetection): startRecording is 0, we will continue as it might be we are in a state of restarting the agent.")
+					continue
+				}
+
 				// timestamp_microseconds_instanceName_regionCoordinates_numberOfChanges_token
 				// 1564859471_6-474162_oprit_577-283-727-375_1153_27.mp4
 				// - Timestamp


### PR DESCRIPTION
## Description

### Pull Request Description

**Title: fix/continue-on-wrong-start-time**

#### Motivation and Improvement

The current implementation of `HandleRecordStream` in `main.go` does not handle cases where `startRecording` is set to 0. This can happen during the restart of the agent, causing potential issues in the recording process and leading to unexpected behavior.

This pull request addresses the issue by adding a check for `startRecording == 0`. If `startRecording` is found to be 0, a log message is generated to indicate that the agent might be restarting, and the process will continue without attempting to handle a recording at this invalid start time.

#### Changes Made

- Added a conditional check for `startRecording == 0` in `HandleRecordStream` function.
- Included a log message to inform that the agent might be in a state of restarting when `startRecording` is 0.
- Ensured the process continues smoothly when this condition is met, preventing potential interruptions or errors.

#### Why This Improves the Project

By implementing this check, we improve the robustness and reliability of the recording process. The changes prevent the system from attempting to handle recordings with an invalid start time of 0, which could lead to errors or undefined behavior. This enhancement ensures smoother operation during agent restarts and contributes to overall system stability.