### PR TITLE
feature/increase-chunk-size

### DIFF
--- a/machinery/src/cloud/Cloud.go
+++ b/machinery/src/cloud/Cloud.go
@@ -737,7 +737,7 @@ func HandleLiveStreamSD(livestreamCursor *packets.QueueCursor, configuration *mo
 						// To avoid base64 encoding, just send the raw []byte chunks as you do here.
 						// If you want to avoid base64, make sure the receiver can handle binary payloads.
 
-						chunkSize := 2 * 1024 // 2KB chunks
+						chunkSize := 25 * 1024 // 25KB chunks
 						var chunks [][]byte
 						for i := 0; i < len(bytes); i += chunkSize {
 							end := i + chunkSize


### PR DESCRIPTION
## Description

### Pull Request Description

#### Title: feature/increase-chunk-size

#### Motivation and Improvement

This pull request aims to improve the efficiency of data transmission in the live stream handling functionality by increasing the chunk size from 2KB to 25KB. The motivation behind this change is to optimize the performance of data transfer, reduce the number of chunks being processed, and minimize the overhead associated with handling smaller chunks.

#### Changes Made

- Updated the chunk size in `machinery/src/cloud/Cloud.go` from 2KB to 25KB in multiple instances:
  ```diff
  - chunkSize := 2 * 1024 // 2KB chunks
  + chunkSize := 25 * 1024 // 25KB chunks
  ```

#### Why This Improves the Project

1. **Increased Efficiency**: Larger chunk sizes reduce the number of chunks that need to be processed, leading to fewer iterations in the loop and less overhead.
2. **Reduced Latency**: By sending larger chunks, the number of transmissions is reduced, which can lead to lower latency in data transmission.
3. **Better Resource Utilization**: Handling fewer, larger chunks can improve CPU and memory usage, as the system spends less time managing chunk boundaries and more time processing actual data.

By implementing this change, the project will benefit from more efficient data handling in live streaming scenarios, leading to potentially smoother and more responsive performance.