### PR TITLE
fix/ovrride-base-width

### DIFF
--- a/machinery/src/components/Kerberos.go
+++ b/machinery/src/components/Kerberos.go
@@ -371,7 +371,7 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	configService.OpenConfig(configDirectory, configuration)
 
 	// We will override the configuration with the environment variables
-	configService.OverrideWithEnvironmentVabriables(configuration)
+	configService.OverrideWithEnvironmentVariables(configuration)
 
 	// Here we are cleaning up everything!
 	if configuration.Config.Offline != "true" {

--- a/machinery/src/components/Kerberos.go
+++ b/machinery/src/components/Kerberos.go
@@ -180,6 +180,9 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	if baseWidth > 0 && baseHeight == 0 {
 		widthAspectRatio := float64(baseWidth) / float64(width)
 		configuration.Config.Capture.IPCamera.BaseHeight = int(float64(height) * widthAspectRatio)
+	} else if baseHeight > 0 && baseWidth > 0 {
+		configuration.Config.Capture.IPCamera.BaseHeight = baseHeight
+		configuration.Config.Capture.IPCamera.BaseWidth = baseWidth
 	} else {
 		configuration.Config.Capture.IPCamera.BaseHeight = height
 		configuration.Config.Capture.IPCamera.BaseWidth = width
@@ -247,6 +250,9 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 		if baseWidth > 0 && baseHeight == 0 {
 			widthAspectRatio := float64(baseWidth) / float64(width)
 			configuration.Config.Capture.IPCamera.BaseHeight = int(float64(height) * widthAspectRatio)
+		} else if baseHeight > 0 && baseWidth > 0 {
+			configuration.Config.Capture.IPCamera.BaseHeight = baseHeight
+			configuration.Config.Capture.IPCamera.BaseWidth = baseWidth
 		} else {
 			configuration.Config.Capture.IPCamera.BaseHeight = height
 			configuration.Config.Capture.IPCamera.BaseWidth = width
@@ -365,7 +371,7 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	configService.OpenConfig(configDirectory, configuration)
 
 	// We will override the configuration with the environment variables
-	configService.OverrideWithEnvironmentVariables(configuration)
+	configService.OverrideWithEnvironmentVabriables(configuration)
 
 	// Here we are cleaning up everything!
 	if configuration.Config.Offline != "true" {

--- a/machinery/src/config/main.go
+++ b/machinery/src/config/main.go
@@ -591,6 +591,10 @@ func StoreConfig(configDirectory string, config models.Config) error {
 		config.Encryption.PrivateKey = encryptionPrivateKey
 	}
 
+	// Reset the basewidth and baseheight
+	config.Capture.IPCamera.BaseWidth = 0
+	config.Capture.IPCamera.BaseHeight = 0
+
 	// Save into database
 	if os.Getenv("DEPLOYMENT") == "factory" || os.Getenv("MACHINERY_ENVIRONMENT") == "kubernetes" {
 		// Write to mongodb


### PR DESCRIPTION
## Description

### Pull Request Title: fix/ovrride-base-width

### Description:

#### Motivation:
The existing logic for setting the base width and height of IP cameras does not account for scenarios where both values are explicitly provided. This can lead to incorrect aspect ratios and unintended behavior in the camera capture configuration.

#### Changes Made:
1. **Kerberos.go**: Added conditions to handle cases where both `baseWidth` and `baseHeight` are greater than zero. This ensures that both values are correctly set when provided.
2. **main.go**: Reset `BaseWidth` and `BaseHeight` values to zero before storing the configuration, ensuring that subsequent operations start with a clean slate.

#### Why It Improves the Project:
By addressing the handling of cases where both `baseWidth` and `baseHeight` are provided, this change ensures more accurate and predictable camera configurations. This leads to better aspect ratios and overall improved functionality in camera capture settings. Additionally, resetting these values in the configuration storage process minimizes the risk of carrying over stale or incorrect values, enhancing the reliability and maintainability of the codebase.