### PR TITLE
fix/debugging-lost-keyframes

### DIFF
--- a/machinery/src/video/mp4.go
+++ b/machinery/src/video/mp4.go
@@ -189,6 +189,11 @@ func (mp4 *MP4) flushPendingVideoSample(nextPTS uint64) bool {
 
 func (mp4 *MP4) AddSampleToTrack(trackID uint32, isKeyframe bool, data []byte, pts uint64) error {
 
+	if isKeyframe && trackID == uint32(mp4.VideoTrack) {
+		log.Log.Debug(fmt.Sprintf("mp4.AddSampleToTrack(): KEYFRAME received - track=%d, PTS=%d, size=%d, sampleCount=%d",
+			trackID, pts, len(data), mp4.SampleCount))
+	}
+
 	if isKeyframe {
 
 		// Determine whether to start a new fragment.


### PR DESCRIPTION
## Live Environment

Access the Pull Request environment [here](https://pr235.api.kerberos.lol)

## Description

## Motivation

This change addresses a critical debugging need related to lost keyframes during video capture and MP4 track writing. Missing or mishandled keyframes can lead to playback issues, broken video segments, and inability to properly seek. Without sufficient logging and defensive code, tracking down the root cause is difficult, especially in live streaming scenarios.

## Why it improves the project

- **Improved FPS tracking stability**  
  Previously, FPS trackers for H.264 and H.265 streams were only updated if already initialised, which could lead to missing FPS calculation in early frames. This change ensures the FPS tracker is always initialised (with a default target FPS), preventing null access and guaranteeing consistent FPS updates.

- **Enhanced keyframe visibility for debugging**  
  Added detailed debug logs when keyframes are received in MP4 track writing and when IDR frames appear in RTSP/H.264 capture. These logs include frame type, NALU details, PTS, size, and sample count, aiding in pinpointing lost or skipped keyframes throughout the pipeline.

- **Better insight into NALU composition**  
  Captured NALU types and sizes for IDR-containing access units, providing richer context around frame data that can assist in determining whether frames are correctly identified and packaged.

These changes will make it significantly easier to diagnose streaming or encoding issues, reduce time to resolution for bugs involving missing keyframes, and improve overall robustness in frame rate and keyframe management.

