### PR TITLE
fix/docker-build-release-action

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -34,7 +34,7 @@ jobs:
           length: 7
       - name: Run Build
         run: |
-          docker build --build-arg VERSION=${{github.event.inputs.tag || github.ref_name}} -t ${{matrix.architecture}} .
+          docker build --provenance=false --build-arg VERSION=${{github.event.inputs.tag || github.ref_name}} -t ${{matrix.architecture}} .
           CID=$(docker create ${{matrix.architecture}})
           docker cp ${CID}:/home/agent ./output-${{matrix.architecture}}
           docker rm ${CID}
@@ -71,7 +71,7 @@ jobs:
           length: 7
       - name: Run Build
         run: |
-          docker build --build-arg VERSION=${{github.event.inputs.tag || github.ref_name}} -t ${{matrix.architecture}} -f Dockerfile.arm64 .
+          docker build --provenance=false --build-arg VERSION=${{github.event.inputs.tag || github.ref_name}} -t ${{matrix.architecture}} -f Dockerfile.arm64 .
           CID=$(docker create ${{matrix.architecture}})
           docker cp ${CID}:/home/agent ./output-${{matrix.architecture}}
           docker rm ${CID}


### PR DESCRIPTION
## Live Environment

Access the Pull Request environment [here](https://pr238.api.kerberos.lol)

## Description

**Fix: Docker build step in `release-create` workflow**  

### Motivation  
The release pipeline builds Docker images for multiple architectures using the `docker build` command. By default Docker attempts to generate *image provenance* metadata (SBOM / attestation). Our CI environment does not consume this data and, on some runners, the provenance generation can:

* Fail on older Docker versions that do not fully support the feature.  
* Add unnecessary overhead to the build, increasing the overall release time.  
* Produce noisy warnings that obscure real build issues.

### What changed  
In **`.github/workflows/release-create.yml`** the `docker build` invocations were updated:

```diff
- docker build --build-arg VERSION=${{...}} -t ${{matrix.architecture}} .
+ docker build --provenance=false --build-arg VERSION=${{...}} -t ${{matrix.architecture}} .
```

The same flag was added to the `Dockerfile.arm64` build step.  

### Why this improves the project  

* **Reliability** – Disabling provenance removes a source of intermittent CI failures caused by unsupported or mis‑configured provenance generation.  
* **Speed** – Skipping the creation of attestation data shortens the build stage, making release creation faster.  
* **Clarity** – The workflow output is cleaner, showing only the information relevant to our release artifacts.  
* **Future‑proofing** – The flag is explicit, so when we decide to adopt provenance we can re‑enable it deliberately rather than relying on Docker’s defaults.

Overall, the change makes the release CI more deterministic, faster, and less prone to environment‑specific issues.