### PR TITLE
Feature/onvif event stream

### DIFF
--- a/machinery/go.mod
+++ b/machinery/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/pion/rtp v1.8.19
 	github.com/pion/webrtc/v4 v4.1.2
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
@@ -58,6 +59,7 @@ require (
 	github.com/clbanning/mxj v1.8.4 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/elgs/gostrgen v0.0.0-20161222160715-9d61ae07eeae // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
@@ -108,6 +110,7 @@ require (
 	github.com/pion/stun/v3 v3.0.0 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
 	github.com/pion/turn/v4 v4.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/machinery/src/components/kerberos.go
+++ b/machinery/src/components/kerberos.go
@@ -341,6 +341,11 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	communication.HandleONVIF = make(chan models.OnvifAction, 10)
 	go onvif.HandleONVIFActions(configuration, communication)
 
+	// Handle ONVIF event stream — opt-in via Capture.ONVIFMotion="true".
+	// Stops when the agent's shared context is cancelled. The function
+	// is a no-op if ONVIFMotion is not enabled.
+	go onvif.HandleONVIFEventStream(*communication.Context, configuration, communication)
+
 	communication.HandleAudio = make(chan models.AudioDataPartial, 10)
 	if rtspBackChannelClient.HasBackChannel {
 		communication.HasBackChannel = true

--- a/machinery/src/config/main.go
+++ b/machinery/src/config/main.go
@@ -377,6 +377,9 @@ func applyAgentEnvVars(configuration *models.Configuration, prefix string, apply
 			case "AGENT_CAPTURE_MOTION":
 				configuration.Config.Capture.Motion = value
 				break
+			case "AGENT_CAPTURE_ONVIF_MOTION":
+				configuration.Config.Capture.ONVIFMotion = value
+				break
 			case "AGENT_CAPTURE_SNAPSHOTS":
 				configuration.Config.Capture.Snapshots = value
 				break

--- a/machinery/src/models/config.go
+++ b/machinery/src/models/config.go
@@ -75,6 +75,14 @@ type Capture struct {
 	Fragmented            string      `json:"fragmented,omitempty" bson:"fragmented,omitempty"`
 	FragmentedDuration    int64       `json:"fragmentedduration,omitempty" bson:"fragmentedduration,omitempty"`
 	PixelChangeThreshold  *int        `json:"pixelChangeThreshold,omitempty"`
+	// ONVIFMotion routes the camera's ONVIF motion events into the
+	// agent's motion-triggered recording pipeline. When "true" the
+	// agent opens an event/stream against the configured ONVIF
+	// endpoint and forwards Motion+Active events to HandleMotion.
+	// Requires Capture.IPCamera.ONVIFXAddr / ONVIFUsername /
+	// ONVIFPassword to be set. Default empty (disabled) keeps the
+	// existing pixel-diff motion detection as the only source.
+	ONVIFMotion string `json:"onvif_motion,omitempty" bson:"onvif_motion,omitempty"`
 }
 
 // IPCamera configuration, such as the RTSP url of the IPCamera and the FPS.

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -3,6 +3,7 @@ package onvif
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -116,18 +117,16 @@ func runStreamOnce(ctx context.Context, configuration *models.Configuration, com
 // closes HandleMotion shortly after cancelling ctx, and a stale event
 // reaching the send would otherwise panic on a closed channel.
 func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.Configuration, communication *models.Communication) {
+	topic := sanitiseTopic(ev.Topic)
 	if ev.Kind != stream.KindMotion {
-		log.Log.Debug("onvif.dispatchEvent(): non-motion event " + ev.Kind.String() + " topic=" + ev.Topic)
+		log.Log.Debug("onvif.dispatchEvent(): non-motion event " + ev.Kind.String() + " topic=" + topic)
 		return
 	}
 	if ev.State != stream.StateActive {
 		return
 	}
-	// A camera replays every property topic's current state as
-	// Initialized on each new subscription, so treating that as a
-	// trigger lets a flapping pull-point manufacture motion.
-	if ev.Operation == stream.PropertyInitialized {
-		log.Log.Debug("onvif.dispatchEvent(): subscription state replay, not a trigger: topic=" + ev.Topic)
+	if !isTransition(ev.Operation) {
+		log.Log.Debug("onvif.dispatchEvent(): " + ev.Operation.String() + " is not a transition, not a trigger: topic=" + topic)
 		return
 	}
 	if configuration.Config.Capture.Recording == "false" {
@@ -136,9 +135,6 @@ func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.C
 	if ctx.Err() != nil {
 		return
 	}
-	// The topic that actually started a recording is the one on-call
-	// needs; the reject path below already names the ones that didn't.
-	log.Log.Debug("onvif.dispatchEvent(): recording trigger " + ev.Kind.String() + " topic=" + ev.Topic)
 
 	dataToPass := models.MotionDataPartial{
 		Timestamp:       time.Now().Unix(),
@@ -147,9 +143,37 @@ func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.C
 	select {
 	case <-ctx.Done():
 	case communication.HandleMotion <- dataToPass:
+		// Logged on the send, not before it: this line records that a
+		// recording started, so a dropped event must not leave one.
+		log.Log.Debug("onvif.dispatchEvent(): recording trigger " + ev.Kind.String() + " topic=" + topic)
 	default:
 		log.Log.Debug("onvif.dispatchEvent(): HandleMotion full, dropping ONVIF motion event")
 	}
+}
+
+// isTransition reports whether an operation represents a state change.
+// A camera replays every property's current state as Initialized on
+// each new subscription and announces removals as Deleted; neither is
+// motion starting. Absent (Unknown) counts — PropertyOperation is
+// optional per WS-Notification and many non-property events omit it.
+func isTransition(op stream.PropertyOperation) bool {
+	return op == stream.PropertyChanged || op == stream.PropertyUnknown
+}
+
+// maxLoggedTopic bounds a topic in the log; the wire imposes no limit,
+// and the reject path logs every event received.
+const maxLoggedTopic = 256
+
+// sanitiseTopic makes a camera-controlled topic safe to concatenate
+// into a log line. logrus's coloured text formatter writes the message
+// unquoted, so a raw newline would let a camera forge entries in the
+// log being used to diagnose it.
+func sanitiseTopic(topic string) string {
+	if len(topic) > maxLoggedTopic {
+		topic = topic[:maxLoggedTopic] + "…(truncated)"
+	}
+	quoted := strconv.Quote(topic)
+	return quoted[1 : len(quoted)-1]
 }
 
 // logStreamError logs at a level matching severity: recreate is loud

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -1,0 +1,124 @@
+package onvif
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/kerberos-io/agent/machinery/src/log"
+	"github.com/kerberos-io/agent/machinery/src/models"
+	"github.com/kerberos-io/onvif/event/stream"
+)
+
+// HandleONVIFEventStream opens an event/stream against the configured
+// ONVIF camera and routes Motion events into communication.HandleMotion
+// so they trigger the existing recording pipeline.
+//
+// The goroutine returns when the stream's context is cancelled (the
+// caller closes ctx when shutting the agent down) or when the camera
+// is not configured for ONVIF.
+//
+// This is a feature behind Capture.ONVIFMotion. When the flag is empty
+// or "false" the goroutine returns immediately, preserving the
+// pixel-diff motion detector as the only source.
+func HandleONVIFEventStream(ctx context.Context, configuration *models.Configuration, communication *models.Communication) {
+	log.Log.Debug("onvif.HandleONVIFEventStream(): started")
+	defer log.Log.Debug("onvif.HandleONVIFEventStream(): finished")
+
+	cfg := configuration.Config.Capture
+	if cfg.ONVIFMotion != "true" {
+		return
+	}
+	camera := cfg.IPCamera
+	if camera.ONVIFXAddr == "" {
+		log.Log.Info("onvif.HandleONVIFEventStream(): ONVIFMotion enabled but ONVIFXAddr is empty; nothing to do")
+		return
+	}
+
+	device, _, err := ConnectToOnvifDevice(&camera)
+	if err != nil {
+		log.Log.Error("onvif.HandleONVIFEventStream(): connect: " + err.Error())
+		return
+	}
+
+	s, err := stream.NewStream(ctx, device, stream.Options{
+		DeviceID: configuration.Name,
+	})
+	if err != nil {
+		log.Log.Error("onvif.HandleONVIFEventStream(): open stream: " + err.Error())
+		return
+	}
+	defer func() {
+		if err := s.Close(); err != nil {
+			log.Log.Debug("onvif.HandleONVIFEventStream(): close: " + err.Error())
+		}
+	}()
+
+	log.Log.Info("onvif.HandleONVIFEventStream(): consuming events for " + configuration.Name)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-s.Events():
+			if !ok {
+				return
+			}
+			dispatchEvent(ev, configuration, communication)
+		case e, ok := <-s.Errors():
+			if !ok {
+				return
+			}
+			logStreamError(e)
+		}
+	}
+}
+
+// dispatchEvent routes a single decoded ONVIF Event into the agent's
+// existing channels. Motion-active events become MotionDataPartial on
+// HandleMotion, matching what the pixel-diff detector emits. Other
+// event kinds are logged at debug for now; a follow-up will wire
+// DigitalInput/Output into the existing inputOutputDeviceMap.
+func dispatchEvent(ev stream.Event, configuration *models.Configuration, communication *models.Communication) {
+	if ev.Kind != stream.KindMotion {
+		log.Log.Debug("onvif.dispatchEvent(): non-motion event " + ev.Kind.String() + " topic=" + ev.Topic)
+		return
+	}
+	// We only fire on the leading edge — StateActive. Motion-stop
+	// handling is a follow-up that needs the recorder state machine
+	// to accept an explicit stop signal; today the recorder uses a
+	// fixed PostRecording timeout.
+	if ev.State != stream.StateActive {
+		return
+	}
+	if configuration.Config.Capture.Recording == "false" {
+		return
+	}
+	dataToPass := models.MotionDataPartial{
+		Timestamp:       time.Now().Unix(),
+		NumberOfChanges: 0, // ONVIF doesn't quantify motion area.
+	}
+	select {
+	case communication.HandleMotion <- dataToPass:
+	default:
+		log.Log.Debug("onvif.dispatchEvent(): HandleMotion full, dropping ONVIF motion event")
+	}
+}
+
+// logStreamError logs at a level matching the severity. Recreate
+// failures are louder because they usually mean the camera is offline.
+func logStreamError(e error) {
+	var recreate stream.ErrRecreateFailed
+	var pull stream.ErrPullFailed
+	var renew stream.ErrRenewFailed
+	switch {
+	case errors.As(e, &recreate):
+		log.Log.Error("onvif.HandleONVIFEventStream(): subscription recreate failed (camera may be offline): " + recreate.Err.Error())
+	case errors.As(e, &renew):
+		log.Log.Debug("onvif.HandleONVIFEventStream(): renew failed (will recover via pull/recreate): " + renew.Err.Error())
+	case errors.As(e, &pull):
+		log.Log.Debug("onvif.HandleONVIFEventStream(): pull failed (will retry): " + pull.Err.Error())
+	default:
+		log.Log.Info("onvif.HandleONVIFEventStream(): stream error: " + e.Error())
+	}
+}

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -129,6 +129,10 @@ func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.C
 	if ctx.Err() != nil {
 		return
 	}
+	// The topic that actually started a recording is the one on-call
+	// needs; the reject path below already names the ones that didn't.
+	log.Log.Debug("onvif.dispatchEvent(): recording trigger " + ev.Kind.String() + " topic=" + ev.Topic)
+
 	dataToPass := models.MotionDataPartial{
 		Timestamp:       time.Now().Unix(),
 		NumberOfChanges: 0, // ONVIF does not quantify motion area.

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -11,29 +11,22 @@ import (
 	"github.com/kerberos-io/onvif/event/stream"
 )
 
-// initialBackoff and maxBackoff bound the wait between successive
-// attempts to (re)open the event stream after a transient construction
-// failure (camera reachable but ONVIF not yet ready, brief network blip
-// at agent boot, etc.). The library itself handles in-stream reconnect;
-// these guards cover the initial-connect path the library cannot see.
+// The library handles in-stream reconnect; these guards cover the
+// initial-connect path the library cannot see.
 const (
 	initialBackoff = time.Second
 	maxBackoff     = 5 * time.Minute
 )
 
 // HandleONVIFEventStream opens an event/stream against the configured
-// ONVIF camera and routes Motion events into communication.HandleMotion
-// so they trigger the existing recording pipeline.
+// ONVIF camera and routes Motion events into communication.HandleMotion.
 //
-// The goroutine retries construction with exponential backoff on
-// transient failure (camera reachable later, credentials reloaded,
-// network restored). It exits cleanly when ctx is cancelled.
-//
-// This is a feature behind Capture.ONVIFMotion. When the flag is not
-// enabled the goroutine returns immediately, preserving the pixel-diff
-// motion detector as the only source. Toggling the flag at runtime
-// requires an agent restart (Capture.ONVIFMotion is read once at
-// goroutine start).
+// Behind the Capture.ONVIFMotion flag; the goroutine returns
+// immediately when not enabled. The flag is read once at start, so
+// toggling at runtime requires an agent restart. On transient
+// construction failure (camera not yet ready at boot, brief network
+// blip, credential reload) the goroutine retries with exponential
+// backoff. Exits when ctx is cancelled.
 func HandleONVIFEventStream(ctx context.Context, configuration *models.Configuration, communication *models.Communication) {
 	log.Log.Debug("onvif.HandleONVIFEventStream(): started")
 	defer log.Log.Debug("onvif.HandleONVIFEventStream(): finished")
@@ -65,10 +58,8 @@ func HandleONVIFEventStream(ctx context.Context, configuration *models.Configura
 	}
 }
 
-// runStreamOnce opens one event stream and consumes from it until ctx
-// is cancelled or the stream exits. Returns true when the caller
-// should retry construction (transient failure), false on clean
-// ctx-driven shutdown.
+// runStreamOnce returns true when the caller should retry construction
+// (transient failure), false on clean ctx-driven shutdown.
 func runStreamOnce(ctx context.Context, configuration *models.Configuration, communication *models.Communication) (retry bool) {
 	camera := configuration.Config.Capture.IPCamera
 
@@ -92,9 +83,9 @@ func runStreamOnce(ctx context.Context, configuration *models.Configuration, com
 
 	log.Log.Info("onvif.HandleONVIFEventStream(): consuming events for " + deviceID)
 
-	// recovering tracks whether we're in a degraded period so the
-	// first successful event after an error streak can log a recovery
-	// line for on-call operators.
+	// recovering = the first successful event after an error streak
+	// logs a recovery line so on-call operators see the clear-of-
+	// condition for the ERROR they were paged on.
 	var recovering bool
 	for {
 		select {
@@ -102,9 +93,6 @@ func runStreamOnce(ctx context.Context, configuration *models.Configuration, com
 			return false
 		case ev, ok := <-s.Events():
 			if !ok {
-				// Lib's run goroutine exited — happens only on ctx
-				// cancel today (library handles its own reconnect),
-				// so treat as clean shutdown.
 				return false
 			}
 			if recovering {
@@ -122,23 +110,16 @@ func runStreamOnce(ctx context.Context, configuration *models.Configuration, com
 	}
 }
 
-// dispatchEvent routes a single decoded ONVIF Event into the agent's
-// existing channels. Motion-active events become MotionDataPartial on
-// HandleMotion, matching what the pixel-diff detector emits.
+// dispatchEvent routes motion-active events to HandleMotion.
 //
-// The ctx pre-check is the shutdown-race guard: between cancel() and
-// close(communication.HandleMotion) the agent leaves a ~3s window in
-// which a stale event could otherwise attempt to send on a closed
-// channel and panic. If ctx is done we drop the event silently — the
-// recording pipeline is already winding down.
+// The ctx pre-check + ctx-in-select guards a shutdown race: the agent
+// closes HandleMotion shortly after cancelling ctx, and a stale event
+// reaching the send would otherwise panic on a closed channel.
 func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.Configuration, communication *models.Communication) {
 	if ev.Kind != stream.KindMotion {
 		log.Log.Debug("onvif.dispatchEvent(): non-motion event " + ev.Kind.String() + " topic=" + ev.Topic)
 		return
 	}
-	// Leading-edge only. Motion-stop wiring into the recorder state
-	// machine is tracked as a follow-up; today the recorder uses a
-	// fixed PostRecording timeout.
 	if ev.State != stream.StateActive {
 		return
 	}
@@ -148,27 +129,21 @@ func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.C
 	if ctx.Err() != nil {
 		return
 	}
-	// Timestamp in seconds matches what computervision/main.go emits;
-	// downstream consumers (capture/main.go) tolerate either second-
-	// or millisecond-precision.
 	dataToPass := models.MotionDataPartial{
 		Timestamp:       time.Now().Unix(),
 		NumberOfChanges: 0, // ONVIF does not quantify motion area.
 	}
 	select {
 	case <-ctx.Done():
-		// Closes the residual race: ctx cancelled between the
-		// pre-check above and reaching this select.
 	case communication.HandleMotion <- dataToPass:
 	default:
 		log.Log.Debug("onvif.dispatchEvent(): HandleMotion full, dropping ONVIF motion event")
 	}
 }
 
-// logStreamError logs at a level matching the severity. Recreate
-// failures are loud because they usually mean the camera is offline;
-// pull/renew failures are debug because the library recovers from them
-// automatically.
+// logStreamError logs at a level matching severity: recreate is loud
+// because it usually means the camera is offline; pull and renew are
+// debug because the library recovers from them automatically.
 func logStreamError(e error) {
 	var recreate stream.ErrRecreateFailed
 	var pull stream.ErrPullFailed
@@ -185,19 +160,13 @@ func logStreamError(e error) {
 	}
 }
 
-// isONVIFMotionEnabled returns true when the Capture.ONVIFMotion flag
-// is set to "true" with case and whitespace tolerance. The rest of the
-// Capture struct uses string flags so we keep the same shape; the
-// difference is that ONVIFMotion defaults to disabled (opt-in), unlike
-// Recording / Motion / Snapshots which default to enabled.
 func isONVIFMotionEnabled(v string) bool {
 	return strings.EqualFold(strings.TrimSpace(v), "true")
 }
 
-// resolveDeviceID returns the most useful identifier for the camera
-// in stream events, logs and metrics. Falls back from configuration
-// name (the operator-supplied label) to the ONVIF endpoint to a
-// constant placeholder so log lines always have something to grep.
+// resolveDeviceID falls back from operator-supplied name to ONVIF
+// endpoint to a constant placeholder so log lines always have
+// something to grep.
 func resolveDeviceID(configName, xaddr string) string {
 	if n := strings.TrimSpace(configName); n != "" {
 		return n
@@ -208,8 +177,7 @@ func resolveDeviceID(configName, xaddr string) string {
 	return "unknown"
 }
 
-// sleepCtx blocks for d or until ctx is cancelled. Returns false if
-// ctx was cancelled, true if the full duration elapsed.
+// sleepCtx returns false if ctx was cancelled, true if d elapsed.
 func sleepCtx(ctx context.Context, d time.Duration) bool {
 	t := time.NewTimer(d)
 	defer t.Stop()

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -3,6 +3,7 @@ package onvif
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/kerberos-io/agent/machinery/src/log"
@@ -10,43 +11,78 @@ import (
 	"github.com/kerberos-io/onvif/event/stream"
 )
 
+// initialBackoff and maxBackoff bound the wait between successive
+// attempts to (re)open the event stream after a transient construction
+// failure (camera reachable but ONVIF not yet ready, brief network blip
+// at agent boot, etc.). The library itself handles in-stream reconnect;
+// these guards cover the initial-connect path the library cannot see.
+const (
+	initialBackoff = time.Second
+	maxBackoff     = 5 * time.Minute
+)
+
 // HandleONVIFEventStream opens an event/stream against the configured
 // ONVIF camera and routes Motion events into communication.HandleMotion
 // so they trigger the existing recording pipeline.
 //
-// The goroutine returns when the stream's context is cancelled (the
-// caller closes ctx when shutting the agent down) or when the camera
-// is not configured for ONVIF.
+// The goroutine retries construction with exponential backoff on
+// transient failure (camera reachable later, credentials reloaded,
+// network restored). It exits cleanly when ctx is cancelled.
 //
-// This is a feature behind Capture.ONVIFMotion. When the flag is empty
-// or "false" the goroutine returns immediately, preserving the
-// pixel-diff motion detector as the only source.
+// This is a feature behind Capture.ONVIFMotion. When the flag is not
+// enabled the goroutine returns immediately, preserving the pixel-diff
+// motion detector as the only source. Toggling the flag at runtime
+// requires an agent restart (Capture.ONVIFMotion is read once at
+// goroutine start).
 func HandleONVIFEventStream(ctx context.Context, configuration *models.Configuration, communication *models.Communication) {
 	log.Log.Debug("onvif.HandleONVIFEventStream(): started")
 	defer log.Log.Debug("onvif.HandleONVIFEventStream(): finished")
 
-	cfg := configuration.Config.Capture
-	if cfg.ONVIFMotion != "true" {
+	if !isONVIFMotionEnabled(configuration.Config.Capture.ONVIFMotion) {
 		return
 	}
-	camera := cfg.IPCamera
-	if camera.ONVIFXAddr == "" {
-		log.Log.Info("onvif.HandleONVIFEventStream(): ONVIFMotion enabled but ONVIFXAddr is empty; nothing to do")
+	if configuration.Config.Capture.IPCamera.ONVIFXAddr == "" {
+		log.Log.Warning("onvif.HandleONVIFEventStream(): ONVIFMotion enabled but ONVIFXAddr is empty; nothing to do")
 		return
 	}
+
+	backoff := initialBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		recoverable := runStreamOnce(ctx, configuration, communication)
+		if !recoverable {
+			return
+		}
+		if !sleepCtx(ctx, backoff) {
+			return
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// runStreamOnce opens one event stream and consumes from it until ctx
+// is cancelled or the stream exits. Returns true when the caller
+// should retry construction (transient failure), false on clean
+// ctx-driven shutdown.
+func runStreamOnce(ctx context.Context, configuration *models.Configuration, communication *models.Communication) (retry bool) {
+	camera := configuration.Config.Capture.IPCamera
 
 	device, _, err := ConnectToOnvifDevice(&camera)
 	if err != nil {
 		log.Log.Error("onvif.HandleONVIFEventStream(): connect: " + err.Error())
-		return
+		return true
 	}
 
-	s, err := stream.NewStream(ctx, device, stream.Options{
-		DeviceID: configuration.Name,
-	})
+	deviceID := resolveDeviceID(configuration.Name, camera.ONVIFXAddr)
+	s, err := stream.NewStream(ctx, device, stream.Options{DeviceID: deviceID})
 	if err != nil {
 		log.Log.Error("onvif.HandleONVIFEventStream(): open stream: " + err.Error())
-		return
+		return true
 	}
 	defer func() {
 		if err := s.Close(); err != nil {
@@ -54,21 +90,33 @@ func HandleONVIFEventStream(ctx context.Context, configuration *models.Configura
 		}
 	}()
 
-	log.Log.Info("onvif.HandleONVIFEventStream(): consuming events for " + configuration.Name)
+	log.Log.Info("onvif.HandleONVIFEventStream(): consuming events for " + deviceID)
 
+	// recovering tracks whether we're in a degraded period so the
+	// first successful event after an error streak can log a recovery
+	// line for on-call operators.
+	var recovering bool
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return false
 		case ev, ok := <-s.Events():
 			if !ok {
-				return
+				// Lib's run goroutine exited — happens only on ctx
+				// cancel today (library handles its own reconnect),
+				// so treat as clean shutdown.
+				return false
 			}
-			dispatchEvent(ev, configuration, communication)
+			if recovering {
+				log.Log.Info("onvif.HandleONVIFEventStream(): event stream recovered for " + deviceID)
+				recovering = false
+			}
+			dispatchEvent(ctx, ev, configuration, communication)
 		case e, ok := <-s.Errors():
 			if !ok {
-				return
+				return false
 			}
+			recovering = true
 			logStreamError(e)
 		}
 	}
@@ -76,17 +124,20 @@ func HandleONVIFEventStream(ctx context.Context, configuration *models.Configura
 
 // dispatchEvent routes a single decoded ONVIF Event into the agent's
 // existing channels. Motion-active events become MotionDataPartial on
-// HandleMotion, matching what the pixel-diff detector emits. Other
-// event kinds are logged at debug for now; a follow-up will wire
-// DigitalInput/Output into the existing inputOutputDeviceMap.
-func dispatchEvent(ev stream.Event, configuration *models.Configuration, communication *models.Communication) {
+// HandleMotion, matching what the pixel-diff detector emits.
+//
+// The ctx pre-check is the shutdown-race guard: between cancel() and
+// close(communication.HandleMotion) the agent leaves a ~3s window in
+// which a stale event could otherwise attempt to send on a closed
+// channel and panic. If ctx is done we drop the event silently — the
+// recording pipeline is already winding down.
+func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.Configuration, communication *models.Communication) {
 	if ev.Kind != stream.KindMotion {
 		log.Log.Debug("onvif.dispatchEvent(): non-motion event " + ev.Kind.String() + " topic=" + ev.Topic)
 		return
 	}
-	// We only fire on the leading edge — StateActive. Motion-stop
-	// handling is a follow-up that needs the recorder state machine
-	// to accept an explicit stop signal; today the recorder uses a
+	// Leading-edge only. Motion-stop wiring into the recorder state
+	// machine is tracked as a follow-up; today the recorder uses a
 	// fixed PostRecording timeout.
 	if ev.State != stream.StateActive {
 		return
@@ -94,11 +145,20 @@ func dispatchEvent(ev stream.Event, configuration *models.Configuration, communi
 	if configuration.Config.Capture.Recording == "false" {
 		return
 	}
+	if ctx.Err() != nil {
+		return
+	}
+	// Timestamp in seconds matches what computervision/main.go emits;
+	// downstream consumers (capture/main.go) tolerate either second-
+	// or millisecond-precision.
 	dataToPass := models.MotionDataPartial{
 		Timestamp:       time.Now().Unix(),
-		NumberOfChanges: 0, // ONVIF doesn't quantify motion area.
+		NumberOfChanges: 0, // ONVIF does not quantify motion area.
 	}
 	select {
+	case <-ctx.Done():
+		// Closes the residual race: ctx cancelled between the
+		// pre-check above and reaching this select.
 	case communication.HandleMotion <- dataToPass:
 	default:
 		log.Log.Debug("onvif.dispatchEvent(): HandleMotion full, dropping ONVIF motion event")
@@ -106,7 +166,9 @@ func dispatchEvent(ev stream.Event, configuration *models.Configuration, communi
 }
 
 // logStreamError logs at a level matching the severity. Recreate
-// failures are louder because they usually mean the camera is offline.
+// failures are loud because they usually mean the camera is offline;
+// pull/renew failures are debug because the library recovers from them
+// automatically.
 func logStreamError(e error) {
 	var recreate stream.ErrRecreateFailed
 	var pull stream.ErrPullFailed
@@ -120,5 +182,41 @@ func logStreamError(e error) {
 		log.Log.Debug("onvif.HandleONVIFEventStream(): pull failed (will retry): " + pull.Err.Error())
 	default:
 		log.Log.Info("onvif.HandleONVIFEventStream(): stream error: " + e.Error())
+	}
+}
+
+// isONVIFMotionEnabled returns true when the Capture.ONVIFMotion flag
+// is set to "true" with case and whitespace tolerance. The rest of the
+// Capture struct uses string flags so we keep the same shape; the
+// difference is that ONVIFMotion defaults to disabled (opt-in), unlike
+// Recording / Motion / Snapshots which default to enabled.
+func isONVIFMotionEnabled(v string) bool {
+	return strings.EqualFold(strings.TrimSpace(v), "true")
+}
+
+// resolveDeviceID returns the most useful identifier for the camera
+// in stream events, logs and metrics. Falls back from configuration
+// name (the operator-supplied label) to the ONVIF endpoint to a
+// constant placeholder so log lines always have something to grep.
+func resolveDeviceID(configName, xaddr string) string {
+	if n := strings.TrimSpace(configName); n != "" {
+		return n
+	}
+	if x := strings.TrimSpace(xaddr); x != "" {
+		return x
+	}
+	return "unknown"
+}
+
+// sleepCtx blocks for d or until ctx is cancelled. Returns false if
+// ctx was cancelled, true if the full duration elapsed.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
 	}
 }

--- a/machinery/src/onvif/events.go
+++ b/machinery/src/onvif/events.go
@@ -123,6 +123,13 @@ func dispatchEvent(ctx context.Context, ev stream.Event, configuration *models.C
 	if ev.State != stream.StateActive {
 		return
 	}
+	// A camera replays every property topic's current state as
+	// Initialized on each new subscription, so treating that as a
+	// trigger lets a flapping pull-point manufacture motion.
+	if ev.Operation == stream.PropertyInitialized {
+		log.Log.Debug("onvif.dispatchEvent(): subscription state replay, not a trigger: topic=" + ev.Topic)
+		return
+	}
 	if configuration.Config.Capture.Recording == "false" {
 		return
 	}

--- a/machinery/src/onvif/events_test.go
+++ b/machinery/src/onvif/events_test.go
@@ -3,6 +3,7 @@ package onvif
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kerberos-io/onvif/event/stream"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeConfig(recording, onvifMotion, name string) *models.Configuration {
@@ -275,4 +277,99 @@ func TestResolveDeviceID_FallbackChain(t *testing.T) {
 			assert.Equal(t, tc.want, resolveDeviceID(tc.cfgName, tc.xaddr))
 		})
 	}
+}
+
+// TestDispatchEvent_OnlyRealTransitionsTrigger — a camera replays every
+// property topic's state on each new subscription (Initialized) and
+// announces removals (Deleted). Neither is a motion transition, and a
+// flapping pull-point would otherwise manufacture recordings out of
+// replayed state. PropertyOperation is optional per WS-Notification, so
+// absent (Unknown) still counts — many non-property events omit it.
+func TestDispatchEvent_OnlyRealTransitionsTrigger(t *testing.T) {
+	tests := []struct {
+		op       stream.PropertyOperation
+		wantSend bool
+	}{
+		{stream.PropertyChanged, true},
+		{stream.PropertyUnknown, true},
+		{stream.PropertyInitialized, false},
+		{stream.PropertyDeleted, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.op.String(), func(t *testing.T) {
+			cfg := makeConfig("true", "true", "cam-1")
+			comm := makeCommunication(1)
+			ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive, Operation: tt.op}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			dispatchEvent(ctx, ev, cfg, comm)
+
+			if tt.wantSend {
+				require.Len(t, comm.HandleMotion, 1, "%v must trigger a recording", tt.op)
+				return
+			}
+			require.Empty(t, comm.HandleMotion, "%v must not trigger a recording", tt.op)
+		})
+	}
+}
+
+// TestSanitiseTopic — ev.Topic is camera-controlled and reaches the log
+// unmodified. logrus's coloured text formatter (the default) writes the
+// message without quoting, so an embedded newline forges whole log
+// lines: a compromised camera can fabricate ERROR entries or spoof
+// another device's id, in the logs an operator is reading to diagnose
+// that very camera. Length is also unbounded on the wire, and the
+// reject path logs every event, so an oversized topic is a cheap way to
+// evict a container's whole retained history.
+func TestSanitiseTopic(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ordinary topic passes through", "tns1:RuleEngine/tnsaxis:VMD3/vmd3_video_1", "tns1:RuleEngine/tnsaxis:VMD3/vmd3_video_1"},
+		{"newline cannot forge a line", "a\nERRO[fake] boom", `a\nERRO[fake] boom`},
+		{"carriage return", "a\rb", `a\rb`},
+		{"tab", "a\tb", `a\tb`},
+		{"NUL", "a\x00b", `a\x00b`},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitiseTopic(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "\n", "no raw newline may survive")
+			assert.NotContains(t, got, "\r", "no raw carriage return may survive")
+		})
+	}
+}
+
+func TestSanitiseTopic_Truncates(t *testing.T) {
+	got := sanitiseTopic(strings.Repeat("x", maxLoggedTopic*2))
+	assert.LessOrEqual(t, len(got), maxLoggedTopic+len("…(truncated)"))
+	assert.Contains(t, got, "truncated")
+}
+
+// TestDispatchEvent_LogsTriggerOnlyWhenSent — the trigger line is the
+// record that a recording started. Logging it before the send means a
+// dropped event (full channel, or shutdown) leaves a line claiming a
+// recording that never began.
+func TestDispatchEvent_LogsTriggerOnlyWhenSent(t *testing.T) {
+	buf := captureDebugLog(t)
+
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := &models.Communication{HandleMotion: make(chan models.MotionDataPartial, 1)}
+	comm.HandleMotion <- models.MotionDataPartial{} // full
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive, Topic: "tns1:VideoSource/MotionAlarm"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	assert.NotContains(t, buf.String(), "recording trigger",
+		"a dropped event must not be logged as a trigger")
+	assert.Contains(t, buf.String(), "dropping", "the drop itself must still be logged")
 }

--- a/machinery/src/onvif/events_test.go
+++ b/machinery/src/onvif/events_test.go
@@ -1,12 +1,14 @@
 package onvif
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
 	"github.com/kerberos-io/agent/machinery/src/models"
 	"github.com/kerberos-io/onvif/event/stream"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,6 +79,48 @@ func TestDispatchEvent_NonMotionKindIgnored(t *testing.T) {
 		t.Fatal("non-motion kinds must not reach HandleMotion")
 	case <-time.After(100 * time.Millisecond):
 	}
+}
+
+// captureDebugLog redirects logrus to a buffer at debug level for the
+// duration of a test and returns what was written. It mutates package
+// globals, so callers must not run in parallel.
+func captureDebugLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevLevel := logrus.StandardLogger().Out, logrus.GetLevel()
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.DebugLevel)
+	t.Cleanup(func() {
+		logrus.SetOutput(prevOut)
+		logrus.SetLevel(prevLevel)
+	})
+	return &buf
+}
+
+// TestDispatchEvent_LogsTheTriggeringTopic — a dispatched event is what
+// actually starts a recording, so its topic is the one an operator needs
+// when a camera records for the wrong reason (or the right reason and
+// nobody can prove which). Rejected events were already logged; without
+// this the triggering topic is only knowable by elimination.
+func TestDispatchEvent_LogsTheTriggeringTopic(t *testing.T) {
+	buf := captureDebugLog(t)
+
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := makeCommunication(1)
+	ev := stream.Event{
+		Kind:  stream.KindMotion,
+		State: stream.StateActive,
+		Topic: "tns1:RuleEngine/tnsaxis:VMD3/vmd3_video_1",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	assert.Contains(t, buf.String(), "tns1:RuleEngine/tnsaxis:VMD3/vmd3_video_1",
+		"the dispatched event's topic must appear in the log")
+	assert.Contains(t, buf.String(), "Motion",
+		"the dispatched event's Kind must appear in the log")
 }
 
 func TestDispatchEvent_RecordingDisabled_DoesNotSend(t *testing.T) {

--- a/machinery/src/onvif/events_test.go
+++ b/machinery/src/onvif/events_test.go
@@ -1,0 +1,186 @@
+package onvif
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kerberos-io/agent/machinery/src/models"
+	"github.com/kerberos-io/onvif/event/stream"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeConfig(recording, onvifMotion, name string) *models.Configuration {
+	return &models.Configuration{
+		Name: name,
+		Config: models.Config{
+			Capture: models.Capture{
+				Recording:   recording,
+				ONVIFMotion: onvifMotion,
+			},
+		},
+	}
+}
+
+func makeCommunication(buffer int) *models.Communication {
+	return &models.Communication{
+		HandleMotion: make(chan models.MotionDataPartial, buffer),
+	}
+}
+
+// --- dispatchEvent ---------------------------------------------------
+
+func TestDispatchEvent_MotionActive_SendsToHandleMotion(t *testing.T) {
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := makeCommunication(1)
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	select {
+	case m := <-comm.HandleMotion:
+		assert.NotZero(t, m.Timestamp)
+	case <-time.After(time.Second):
+		t.Fatal("expected motion data on HandleMotion")
+	}
+}
+
+func TestDispatchEvent_MotionInactive_DoesNotSend(t *testing.T) {
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := makeCommunication(1)
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateInactive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	select {
+	case <-comm.HandleMotion:
+		t.Fatal("inactive motion must not reach HandleMotion (motion-stop is a follow-up)")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestDispatchEvent_NonMotionKindIgnored(t *testing.T) {
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := makeCommunication(1)
+	ev := stream.Event{Kind: stream.KindDigitalInput, State: stream.StateActive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	select {
+	case <-comm.HandleMotion:
+		t.Fatal("non-motion kinds must not reach HandleMotion")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestDispatchEvent_RecordingDisabled_DoesNotSend(t *testing.T) {
+	cfg := makeConfig("false", "true", "cam-1")
+	comm := makeCommunication(1)
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchEvent(ctx, ev, cfg, comm)
+
+	select {
+	case <-comm.HandleMotion:
+		t.Fatal("Recording=false must gate the send (matches computervision behaviour)")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestDispatchEvent_HandleMotionFull_DropsRatherThanBlocks(t *testing.T) {
+	cfg := makeConfig("true", "true", "cam-1")
+	// Pre-fill the buffer so the next send would block.
+	comm := &models.Communication{HandleMotion: make(chan models.MotionDataPartial, 1)}
+	comm.HandleMotion <- models.MotionDataPartial{}
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		dispatchEvent(ctx, ev, cfg, comm)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatchEvent must drop when HandleMotion is full, not block")
+	}
+}
+
+func TestDispatchEvent_CtxCancelledAndHandleMotionClosed_DoesNotPanic(t *testing.T) {
+	// Regression for the shutdown race: between cancel() and
+	// close(HandleMotion) the agent leaves a 3s window. If dispatchEvent
+	// runs in that window AFTER the channel is closed, a non-protected
+	// send would panic. The ctx pre-check must short-circuit before the
+	// send is attempted.
+	cfg := makeConfig("true", "true", "cam-1")
+	comm := &models.Communication{HandleMotion: make(chan models.MotionDataPartial, 1)}
+	close(comm.HandleMotion)
+	ev := stream.Event{Kind: stream.KindMotion, State: stream.StateActive}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled, matching the shutdown sequence
+
+	assert.NotPanics(t, func() {
+		dispatchEvent(ctx, ev, cfg, comm)
+	})
+}
+
+// --- isONVIFMotionEnabled --------------------------------------------
+
+func TestIsONVIFMotionEnabled_CaseAndWhitespace(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{" true", true},
+		{"true ", true},
+		{"  true  ", true},
+		{"false", false},
+		{"False", false},
+		{"", false},
+		{"yes", false},
+		{"1", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, isONVIFMotionEnabled(tc.in))
+		})
+	}
+}
+
+// --- resolveDeviceID -------------------------------------------------
+
+func TestResolveDeviceID_FallbackChain(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgName string
+		xaddr   string
+		want    string
+	}{
+		{"name_set", "front-door", "192.168.1.10", "front-door"},
+		{"name_empty_xaddr_set", "", "192.168.1.10", "192.168.1.10"},
+		{"name_whitespace_only_xaddr_set", "  ", "192.168.1.10", "192.168.1.10"},
+		{"both_empty", "", "", "unknown"},
+		{"name_with_trailing_whitespace", "cam-2  ", "192.168.1.10", "cam-2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveDeviceID(tc.cfgName, tc.xaddr))
+		})
+	}
+}

--- a/machinery/src/onvif/events_test.go
+++ b/machinery/src/onvif/events_test.go
@@ -123,6 +123,54 @@ func TestDispatchEvent_LogsTheTriggeringTopic(t *testing.T) {
 		"the dispatched event's Kind must appear in the log")
 }
 
+// TestDispatchEvent_PropertyOperation — a camera replays the current
+// state of every property topic as Initialized whenever a pull-point
+// subscription is created. If that counts as a trigger, every
+// reconnect restarts a recording for any motion property that happens
+// to be active, and a flapping subscription manufactures motion out of
+// nothing. Only reject Initialized specifically: PropertyOperation is
+// optional per WS-Notification and absent on many non-property events,
+// which decode reports as PropertyUnknown.
+func TestDispatchEvent_PropertyOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       stream.PropertyOperation
+		wantSend bool
+	}{
+		{"changed is a real transition", stream.PropertyChanged, true},
+		{"absent attribute still counts", stream.PropertyUnknown, true},
+		{"initialized is a subscription state replay", stream.PropertyInitialized, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := makeConfig("true", "true", "cam-1")
+			comm := makeCommunication(1)
+			ev := stream.Event{
+				Kind:      stream.KindMotion,
+				State:     stream.StateActive,
+				Operation: tt.op,
+				Topic:     "tns1:RuleEngine/tnsaxis:VMD3/vmd3_video_1",
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			dispatchEvent(ctx, ev, cfg, comm)
+
+			select {
+			case <-comm.HandleMotion:
+				if !tt.wantSend {
+					t.Fatalf("%v must not trigger a recording", tt.op)
+				}
+			case <-time.After(100 * time.Millisecond):
+				if tt.wantSend {
+					t.Fatalf("%v must trigger a recording", tt.op)
+				}
+			}
+		})
+	}
+}
+
 func TestDispatchEvent_RecordingDisabled_DoesNotSend(t *testing.T) {
 	cfg := makeConfig("false", "true", "cam-1")
 	comm := makeCommunication(1)


### PR DESCRIPTION
# Add ONVIF event-stream motion source

## Disclaimer

I am currently testing these changes. We are opening this PR now to get early feedback and pointers on direction (in case we have gone too bananas) - perhaps this is not the path you were intending.

## Motivation

Closes [#173](https://github.com/kerberos-io/agent/issues/173). Today the only motion-triggered recording source is the pixel-diff detector in `computervision/`. ONVIF cameras (AXIS in particular) emit their own native motion events that are more accurate, lower-CPU, and configurable in the camera's own analytics UI. This PR lets the agent consume those events.

The earlier attempt at this — [#194](https://github.com/kerberos-io/agent/pull/194) — was set aside on @cedricve's direction:

> "I think we should extend the ONVIF library first to make this more isolated. So we just have a go channel exposed from where we can consume those messages, and hide the complexity of the ONVIF protocol."

That library work lives in [kerberos-io/onvif#5](https://github.com/kerberos-io/onvif/pull/5) — new `event/stream` sub-package. **This PR depends on that one landing first** so the `replace` directive in `machinery/go.mod` can be removed and a tagged release pinned. Until then the directive points at a pinned commit on the fork; the official Dockerfile builds unchanged.

## What ships

```
machinery/
├── go.mod                      replace directive (TEMPORARY, see below)
├── src/
│   ├── config/main.go          AGENT_CAPTURE_ONVIF_MOTION env handler
│   ├── models/Config.go        Capture.ONVIFMotion field
│   ├── components/Kerberos.go  goroutine launch alongside HandleONVIFActions
│   └── onvif/
│       ├── events.go           (NEW) Stream consumer + dispatch
│       └── events_test.go      (NEW)
```

The user-visible surface is a single new flag:

| | |
|---|---|
| **Config field** | `Capture.ONVIFMotion` (string `"true"`/`"false"`, defaults disabled) |
| **Env var** | `AGENT_CAPTURE_ONVIF_MOTION` |
| **JSON key** | `capture.onvif_motion` |

When enabled, the agent opens an event stream against the camera's ONVIF endpoint and forwards `KindMotion` + `StateActive` events to the existing `communication.HandleMotion` channel — the same channel the pixel-diff detector and MQTT-motion source feed. The recorder pipeline downstream sees a familiar `MotionDataPartial` and triggers recording as today.

## Architecture

`HandleONVIFEventStream` is a long-running goroutine launched in `Kerberos.go` alongside the existing `HandleONVIFActions` (PTZ handler):

```
RunAgent ──► go HandleONVIFEventStream(ctx, configuration, communication)
                  │
                  └─► runStreamOnce: open stream.NewStream against the camera
                          │
                          ├─► for event := range s.Events()  ──► dispatchEvent ──► HandleMotion
                          └─► for err   := range s.Errors()  ──► logStreamError
```

The heavy lifting (pull-point subscription, renew loop, reconnect-with-backoff, vendor topic classification, SOAP fault extraction) lives in the `event/stream` library and is the same code the lib PR adds.

Three concurrency concerns are explicitly handled in `events.go`:

1. **Initial-connect retry with exponential backoff** — `stream.NewStream` failures (camera not yet ready at agent boot, brief network blip, credentials reloaded) are recoverable. The library handles in-stream reconnect; the agent layer wraps construction in a retry loop covering the gap the library cannot see.
2. **Shutdown-race guard** — the agent closes `communication.HandleMotion` ~3s after cancelling the goroutine's context. `dispatchEvent` pre-checks `ctx.Err()` and uses `select { case <-ctx.Done(); case communication.HandleMotion <- ...; default: }` so a buffered event arriving during shutdown cannot panic on a closed channel.
3. **Recovery observability** — a `recovering` flag set on the first `Errors` arrival logs `Info "event stream recovered for <id>"` on the next successful event, so on-call operators see the clear-of-condition for an `ERROR` they were paged on.

## Design rationale

### Opt-in flag, default disabled

`Capture.ONVIFMotion` defaults to empty/disabled. Existing deployments using the pixel-diff detector see no behavioural change. Activating ONVIF motion is a one-line compose / env change. No data migration, no config bump.

### Routed into `HandleMotion`, not a new channel

Two reasons: (a) the recorder state machine is the same regardless of motion source — adding a parallel channel would mean duplicating downstream wiring; (b) MQTT motion already follows this convention, so ONVIF as a third source is the same shape. Trade-off acknowledged: motion-STOP signalling is not wired through `HandleMotion` today, so this PR only triggers on motion-START (the leading edge). The recorder's existing `PostRecording` timeout decides when to stop. Motion-STOP wiring is tracked as a follow-up — it needs a recorder state-machine change beyond this PR's scope.

### Case-insensitive flag parsing (`isONVIFMotionEnabled`)

The rest of `Capture` is strict-string equality, but a user setting `AGENT_CAPTURE_ONVIF_MOTION=True` (capital T) silently doing nothing is the kind of footgun reviewers always flag. The new flag normalises case and whitespace via `strings.EqualFold(strings.TrimSpace(v), "true")`. Unit-tested across 11 inputs.

### DeviceID fallback chain (`resolveDeviceID`)

Logs and downstream metrics need a non-empty identifier. Falls back from `configuration.Name` to the camera's `ONVIFXAddr` to a constant `"unknown"`. Without this an unconfigured `Name` produces empty grep targets in the operator's logs.

### Typed-error routing in `logStreamError`

The library exposes `stream.ErrPullFailed`, `ErrRenewFailed`, `ErrRecreateFailed`. `logStreamError` matches via `errors.As` and logs at severity matching the failure mode: recreate is loud (camera may be offline), pull and renew are debug (library recovers automatically). Operators do not get paged for transient pulls.

### Default-arm drop on full `HandleMotion`

The pixel-diff and MQTT sources do blocking sends. Adding a third source that drops on full preserves the existing back-pressure semantics rather than starving the stream goroutine and the renewal it depends on. A `Debug` line records each drop.

## Verification

* `events_test.go`: 8 test functions covering dispatch contract (motion-active sends, inactive ignored, non-motion ignored, `Recording=false` gates, full-channel drops, closed-channel does not panic), case-insensitive flag, DeviceID fallback chain.
* Build + `go test -race ./src/onvif/...` clean.
* `go build ./...` for the affected packages (`onvif`, `config`, `models`, `components`) clean. The full module build requires `libavcodec`/`libavutil`/`libswscale` dev headers (capture package); not impacted by this PR.
* Smoke-tested against `roleoroleo/onvif_simple_server`: agent goroutine launches under the flag, `consuming events for <name>` log line appears, subscription is created and pull-loop iterates against the simulator.
* Real AXIS hardware verification by an integrator is in progress; the Docker test image and handoff guide live in the branch but are not committed (local-only working files).

## What's NOT in this PR

* **No motion-STOP wiring** into `capture/main.go`'s recorder. Needs a new explicit-stop signal in the recorder state machine. Something to consider to add as an alternative to pre/post recording config.
* **No replacement of the ad-hoc pull-point polling in `cloud/Cloud.go` heartbeat.** That code currently maintains `inputOutputDeviceMap` for digital I/O. Migrating it to a `stream.Stream` consumer is a separate PR — keeps this one small and reversible.
* **No UI field** for `Capture.ONVIFMotion`. Activation is via env var or `config.json` for this first release; UI exposure can follow once real-camera verification is in.
* **No webhook/BaseNotification path.** Pull-point only; matches HA's and Milestone's production-grade default.

## Temporary go.mod note

`machinery/go.mod` carries a `replace github.com/kerberos-io/onvif => github.com/sharedjourney/kerberos-onvif <pseudo-version>` directive pinned to the commit on the lib PR's branch. This **must be removed before merge** — once the lib PR lands and `kerberos-io/onvif` ships a tagged release with the `event/stream` package, drop the `replace` and bump the version in `require`. The directive is documented inline in `go.mod` with the removal recipe.

## Migration notes for users

* Existing users: nothing changes. The pixel-diff detector continues to work unchanged.
* Users wanting ONVIF-driven motion: set `AGENT_CAPTURE_ONVIF_MOTION=true` and ensure `AGENT_CAPTURE_IPCAMERA_ONVIF_XADDR` / `_USERNAME` / `_PASSWORD` are correct. AXIS motion source is auto-detected — no topic-filter configuration needed.
