### PR TITLE
feature/add-bump-release-workflow

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,68 @@
+name: Bump release
+
+# Manually "promote" the agent to a new release.
+# Pick which part of the semantic version to bump, this workflow computes the
+# next vMAJOR.MINOR.PATCH tag, pushes it and triggers the existing
+# release-create pipeline to build and publish the images and GitHub release.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Which part of the version to bump"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  bump-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+          latest=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          latest=${latest:-v0.0.0}
+          echo "Latest tag: $latest"
+          version=${latest#v}
+          IFS='.' read -r major minor patch <<< "$version"
+          case "${{ github.event.inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          next="v${major}.${minor}.${patch}"
+          echo "Next tag: $next"
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      # A tag pushed with the default GITHUB_TOKEN does not trigger other
+      # workflows, so invoke the release pipeline explicitly for the new tag.
+      - name: Trigger release pipeline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-create.yml \
+            --ref "${{ steps.version.outputs.tag }}" \
+            -f tag="${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Description

## Why

Releasing currently depends on manual version calculation, tag creation, and triggering the release pipeline. That adds unnecessary friction and makes the process easy to get wrong, especially around semantic versioning and workflow chaining.

## What this improves

This adds a manual GitHub Actions workflow to bump the release version in a controlled way by choosing `major`, `minor`, or `patch`. The workflow:

- finds the latest semantic version tag
- computes the next version automatically
- creates and pushes the new tag
- explicitly triggers the existing release pipeline for that tag

This improves the project by making releases more consistent, less error-prone, and easier to operate. It gives us a single, repeatable path for promoting a new release without relying on manual tagging steps or release-specific tribal knowledge.