### PR TITLE
fix(machinery): prevent makeslice panic when liveview dims are poisoned

### DIFF
--- a/machinery/src/components/kerberos.go
+++ b/machinery/src/components/kerberos.go
@@ -177,19 +177,10 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 	configuration.Config.Capture.IPCamera.Height = height
 
 	// Set the liveview width and height, this is used for the liveview and motion regions (drawing on the hub).
-	baseWidth := config.Capture.IPCamera.BaseWidth
-	baseHeight := config.Capture.IPCamera.BaseHeight
-	// If the liveview height is not set, we will calculate it based on the width and aspect ratio of the camera.
-	if baseWidth > 0 && baseHeight == 0 {
-		widthAspectRatio := float64(baseWidth) / float64(width)
-		configuration.Config.Capture.IPCamera.BaseHeight = int(float64(height) * widthAspectRatio)
-	} else if baseHeight > 0 && baseWidth > 0 {
-		configuration.Config.Capture.IPCamera.BaseHeight = baseHeight
-		configuration.Config.Capture.IPCamera.BaseWidth = baseWidth
-	} else {
-		configuration.Config.Capture.IPCamera.BaseHeight = height
-		configuration.Config.Capture.IPCamera.BaseWidth = width
-	}
+	// ResolveBaseDimensions gates the aspect-ratio compute on width/height > 0
+	// so a not-yet-probed stream can't poison the dimensions and crash resize.
+	configuration.Config.Capture.IPCamera.BaseWidth, configuration.Config.Capture.IPCamera.BaseHeight =
+		utils.ResolveBaseDimensions(config.Capture.IPCamera.BaseWidth, config.Capture.IPCamera.BaseHeight, width, height)
 
 	// Set the SPS and PPS values in the configuration.
 	configuration.Config.Capture.IPCamera.SPSNALUs = [][]byte{videoStream.SPS}
@@ -247,19 +238,8 @@ func RunAgent(configDirectory string, configuration *models.Configuration, commu
 
 		// If we have a substream, we need to set the width and height of the substream. (so we will override above information)
 		// Set the liveview width and height, this is used for the liveview and motion regions (drawing on the hub).
-		baseWidth := config.Capture.IPCamera.BaseWidth
-		baseHeight := config.Capture.IPCamera.BaseHeight
-		// If the liveview height is not set, we will calculate it based on the width and aspect ratio of the camera.
-		if baseWidth > 0 && baseHeight == 0 {
-			widthAspectRatio := float64(baseWidth) / float64(width)
-			configuration.Config.Capture.IPCamera.BaseHeight = int(float64(height) * widthAspectRatio)
-		} else if baseHeight > 0 && baseWidth > 0 {
-			configuration.Config.Capture.IPCamera.BaseHeight = baseHeight
-			configuration.Config.Capture.IPCamera.BaseWidth = baseWidth
-		} else {
-			configuration.Config.Capture.IPCamera.BaseHeight = height
-			configuration.Config.Capture.IPCamera.BaseWidth = width
-		}
+		configuration.Config.Capture.IPCamera.BaseWidth, configuration.Config.Capture.IPCamera.BaseHeight =
+			utils.ResolveBaseDimensions(config.Capture.IPCamera.BaseWidth, config.Capture.IPCamera.BaseHeight, width, height)
 	}
 
 	// We are creating a queue to store the RTSP frames in, these frames will be

--- a/machinery/src/utils/main.go
+++ b/machinery/src/utils/main.go
@@ -427,10 +427,47 @@ func ResizeImage(img image.Image, newWidth uint, newHeight uint) (*image.Image, 
 		return nil, errors.New("image is nil")
 	}
 
+	// Callers cast int->uint, so a negative or poisoned int (e.g. MinInt from
+	// `int(float * +Inf)` when the source width is 0) wraps to a near-MaxUint
+	// value here and crashes nfnt/resize's allocator with "makeslice: len out
+	// of range". Clamp anything past a sane camera ceiling to 0 ("auto" in
+	// nfnt — preserves aspect from the source).
+	const maxDim uint = 8192
+	if newWidth > maxDim {
+		newWidth = 0
+	}
+	if newHeight > maxDim {
+		newHeight = 0
+	}
+
 	// resize to width 640 using Lanczos resampling
 	// and preserve aspect ratio
 	m := resize.Resize(newWidth, newHeight, img, resize.Lanczos3)
 	return &m, nil
+}
+
+// ResolveBaseDimensions resolves the liveview/motion base dimensions for a
+// stream given the (optionally configured) base width/height and the camera's
+// probed source width/height. It returns the width and height that should be
+// stored on the configuration.
+//
+// The aspect-ratio branch is gated on width>0 && height>0: a not-yet-probed
+// stream has width=height=0, which previously made the ratio +Inf and
+// int(float * +Inf) yield MinInt. That poisoned value, later cast to uint at
+// the ResizeImage call sites, wrapped to ~MaxUint and crashed resize with
+// "makeslice: len out of range". When the source isn't probed yet we fall back
+// to the source dimensions (0,0 -> "auto") instead.
+func ResolveBaseDimensions(baseWidth, baseHeight, width, height int) (int, int) {
+	if baseWidth > 0 && baseHeight == 0 && width > 0 && height > 0 {
+		// Derive the height from the configured width and the source aspect ratio.
+		widthAspectRatio := float64(baseWidth) / float64(width)
+		return baseWidth, int(float64(height) * widthAspectRatio)
+	} else if baseHeight > 0 && baseWidth > 0 {
+		// Both base dimensions are configured; honor them as-is.
+		return baseWidth, baseHeight
+	}
+	// Nothing usable configured (or source not probed yet): use source dimensions.
+	return width, height
 }
 
 func ResizeHeightWithAspectRatio(newWidth int, width int, height int) (int, int) {

--- a/machinery/src/utils/resize_test.go
+++ b/machinery/src/utils/resize_test.go
@@ -1,0 +1,124 @@
+package utils
+
+import (
+	"image"
+	"math"
+	"testing"
+)
+
+func TestResolveBaseDimensions(t *testing.T) {
+	tests := []struct {
+		name                  string
+		baseWidth, baseHeight int
+		width, height         int
+		wantWidth, wantHeight int
+	}{
+		{
+			name:      "base width set, height derived from aspect ratio",
+			baseWidth: 640, baseHeight: 0,
+			width: 1920, height: 1080,
+			wantWidth: 640, wantHeight: 360,
+		},
+		{
+			name:      "both base dimensions configured are honored",
+			baseWidth: 640, baseHeight: 480,
+			width: 1920, height: 1080,
+			wantWidth: 640, wantHeight: 480,
+		},
+		{
+			name:      "no base configured falls back to source dimensions",
+			baseWidth: 0, baseHeight: 0,
+			width: 1920, height: 1080,
+			wantWidth: 1920, wantHeight: 1080,
+		},
+		{
+			// Regression: a not-yet-probed stream has width=height=0. The old
+			// aspect-ratio branch divided by zero (float * +Inf -> MinInt) and
+			// poisoned BaseHeight, later crashing resize with makeslice panic.
+			name:      "unprobed stream (width=0) does not poison dimensions",
+			baseWidth: 640, baseHeight: 0,
+			width: 0, height: 0,
+			wantWidth: 0, wantHeight: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWidth, gotHeight := ResolveBaseDimensions(tt.baseWidth, tt.baseHeight, tt.width, tt.height)
+			if gotWidth != tt.wantWidth || gotHeight != tt.wantHeight {
+				t.Fatalf("ResolveBaseDimensions(%d,%d,%d,%d) = (%d,%d), want (%d,%d)",
+					tt.baseWidth, tt.baseHeight, tt.width, tt.height,
+					gotWidth, gotHeight, tt.wantWidth, tt.wantHeight)
+			}
+		})
+	}
+}
+
+func TestResolveBaseDimensionsNeverNegative(t *testing.T) {
+	// Whatever the inputs, the resolved dimensions must never be negative,
+	// otherwise the uint cast at the resize call sites wraps to ~MaxUint.
+	for _, c := range [][4]int{
+		{640, 0, 0, 0},
+		{640, 0, 0, 1080},
+		{640, 0, 1920, 0},
+		{0, 0, 0, 0},
+	} {
+		w, h := ResolveBaseDimensions(c[0], c[1], c[2], c[3])
+		if w < 0 || h < 0 {
+			t.Fatalf("ResolveBaseDimensions(%v) produced negative dims (%d,%d)", c, w, h)
+		}
+	}
+}
+
+func TestResizeImageClampsPoisonedDimensions(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 320, 240))
+
+	// uint(math.MinInt) is the value produced when a poisoned int (from
+	// int(float * +Inf)) is cast to uint at a call site. It must not panic
+	// nfnt/resize's allocator; it should fall back to source-aspect resize.
+	// Compute via a runtime int so the conversion doesn't overflow at compile time.
+	minInt := math.MinInt
+	poison := uint(minInt)
+
+	resized, err := ResizeImage(src, poison, poison)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resized == nil {
+		t.Fatalf("expected an image, got nil")
+	}
+	b := (*resized).Bounds()
+	if b.Dx() != 320 || b.Dy() != 240 {
+		t.Fatalf("poisoned dims should fall back to source size, got %dx%d", b.Dx(), b.Dy())
+	}
+}
+
+func TestResizeImageClampsAboveCameraCeiling(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 320, 240))
+
+	// A width beyond any sane camera resolution is treated as "auto" (0).
+	resized, err := ResizeImage(src, 100000, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b := (*resized).Bounds()
+	if b.Dx() != 320 || b.Dy() != 240 {
+		t.Fatalf("oversized width should fall back to source size, got %dx%d", b.Dx(), b.Dy())
+	}
+}
+
+func TestResizeImageNormalResizeStillWorks(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
+
+	resized, err := ResizeImage(src, 640, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b := (*resized).Bounds()
+	if b.Dx() != 640 {
+		t.Fatalf("expected width 640, got %d", b.Dx())
+	}
+	if b.Dy() != 360 {
+		t.Fatalf("expected aspect-preserved height 360, got %d", b.Dy())
+	}
+}


### PR DESCRIPTION
# fix(machinery): prevent makeslice panic when liveview dims are poisoned

## Summary

Fixes a hard crash (`runtime error: makeslice: len out of range`) that took down agents in `HandleLiveStreamSD` when publishing liveview snapshots over MQTT. The panic was reproducible with a specific brand of cameras, whose stream can be advertised before it has been probed, so the agent briefly sees `Width=0`/`Height=0`.

## Root cause

When the liveview base width is configured but the base height is not, the agent derives the height from the camera's source aspect ratio. With an unprobed stream the source width is `0`, so `float64(baseWidth) / float64(0)` is `+Inf`, and `int(float64(height) * +Inf)` evaluates to `MinInt`. That poisoned value is stored as `BaseHeight`, then cast `int -> uint` at the `ResizeImage` call sites, wrapping to a near-`MaxUint` value that `nfnt/resize`'s allocator tries to `make` a slice for, panicking the process.

## Fix

Two stacked defenses so a single bad value can't reach the allocator.

First, the liveview base-dimension logic is extracted into `utils.ResolveBaseDimensions`, which gates the aspect-ratio branch on `width > 0 && height > 0`. An unprobed stream now falls back to source dimensions (`0,0`, i.e. "auto") instead of dividing by zero. This also collapses the two identical inline blocks in `RunAgent` (main and sub stream) into one tested helper.

Second, `ResizeImage` clamps any `newWidth`/`newHeight` above a sane camera ceiling (`8192`) down to `0` ("auto"). This is the backstop covering all three call sites (cloud, capture, websocket) at once, so any future caller that passes a wrapped or negative `uint` silently falls back to source-aspect resize rather than crashing.
