### PR TITLE
feature/remove-default-value-for-max-directory-size

### DIFF
--- a/machinery/data/config/config.json
+++ b/machinery/data/config/config.json
@@ -7,7 +7,7 @@
 	"offline": "false",
 	"auto_clean": "true",
 	"remove_after_upload": "true",
-	"max_directory_size": 100,
+	"max_directory_size": 0,
 	"timezone": "Africa/Ceuta",
 	"capture": {
 		"name": "",


### PR DESCRIPTION
## Description

Currently, the default `max_directory_size` in config.json is set to 100 (likely MB), imposing an artificial limit on directory growth that can prematurely restrict operations for users with larger datasets.

This PR changes the default to 0, effectively disabling the limit by default and requiring explicit configuration only when needed.

This improves the project by enhancing usability and flexibility—users no longer hit unexpected size barriers out-of-the-box, reducing support issues and enabling seamless handling of larger captures without manual config tweaks.