### PR TITLE
fix/default-pixel-threshold-value

### DIFF
--- a/machinery/src/computervision/main.go
+++ b/machinery/src/computervision/main.go
@@ -231,12 +231,12 @@ func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Conf
 													"mainWidth":  configuration.Config.Capture.IPCamera.Width,
 													"mainHeight": configuration.Config.Capture.IPCamera.Height,
 													"regions":    motionRectangles,
-													"polygon":    regionPolygons,												// Motion sensitivity = the pixel-change threshold that must
-												// be exceeded before motion triggers. The live view renders
-												// a reference square of sqrt(threshold) px (in this MOTION
-												// frame's pixel space) so the user can visually gauge how
-												// large a moving object must be before it is detected.
-												"pixelChangeThreshold": pixelThreshold,												},
+													"polygon":    regionPolygons, // Motion sensitivity = the pixel-change threshold that must
+													// be exceeded before motion triggers. The live view renders
+													// a reference square of sqrt(threshold) px (in this MOTION
+													// frame's pixel space) so the user can visually gauge how
+													// large a moving object must be before it is detected.
+													"pixelChangeThreshold": pixelThreshold},
 											},
 										}
 										payload, err := models.PackageMQTTMessage(configuration, message)

--- a/machinery/src/computervision/main.go
+++ b/machinery/src/computervision/main.go
@@ -47,7 +47,7 @@ func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Conf
 
 	if motionDisabled {
 
-		log.Log.Info("computervision.main.ProcessMotion(): motion detection disabled (pixelChangeThreshold set to 0), skipping.")
+		log.Log.Warning("computervision.main.ProcessMotion(): motion detection is DISABLED because pixelChangeThreshold is set to 0 (nil/unset would default to 150). If motion detection is expected to be running, set capture.pixelChangeThreshold to a positive value (150 recommended) or AGENT_CAPTURE_PIXEL_CHANGE, then restart/update the agent.")
 
 	} else if continuousMode && !hasMotionRegion {
 

--- a/machinery/src/computervision/main.go
+++ b/machinery/src/computervision/main.go
@@ -236,8 +236,9 @@ func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Conf
 													// a reference square of sqrt(threshold) px (in this MOTION
 													// frame's pixel space) so the user can visually gauge how
 													// large a moving object must be before it is detected.
-													"pixelChangeThreshold": pixelThreshold},
+												"pixelChangeThreshold": pixelThreshold,
 											},
+										},
 										}
 										payload, err := models.PackageMQTTMessage(configuration, message)
 										if err == nil {

--- a/machinery/src/computervision/main.go
+++ b/machinery/src/computervision/main.go
@@ -47,7 +47,7 @@ func ProcessMotion(motionCursor *packets.QueueCursor, configuration *models.Conf
 
 	if motionDisabled {
 
-		log.Log.Warning("computervision.main.ProcessMotion(): motion detection is DISABLED because pixelChangeThreshold is set to 0 (nil/unset would default to 150). If motion detection is expected to be running, set capture.pixelChangeThreshold to a positive value (150 recommended) or AGENT_CAPTURE_PIXEL_CHANGE, then restart/update the agent.")
+		log.Log.Warning("computervision.main.ProcessMotion(): motion detection is DISABLED because pixelChangeThreshold is set to 0 or less (nil/unset would default to 150). If motion detection is expected to be running, set capture.pixelChangeThreshold to a positive value (150 recommended) or AGENT_CAPTURE_PIXEL_CHANGE, then restart/update the agent.")
 
 	} else if continuousMode && !hasMotionRegion {
 

--- a/machinery/src/config/main.go
+++ b/machinery/src/config/main.go
@@ -648,6 +648,17 @@ func applyAgentEnvVars(configuration *models.Configuration, prefix string, apply
 		}
 	}
 
+	// Motion sensitivity: nil/unset must still resolve to the default (150), not
+	// be left nil. An explicit 0 (temporary "disable motion detection" switch
+	// from the UI) is a real, non-nil value and must NOT be touched here. Only
+	// applied for the effective configuration (applyDefaults), not for the
+	// separate global/custom views, so a missing value in one layer can still be
+	// inherited from the other instead of being masked by this default.
+	if applyDefaults && configuration.Config.Capture.PixelChangeThreshold == nil {
+		defaultPixelChangeThreshold := 150
+		configuration.Config.Capture.PixelChangeThreshold = &defaultPixelChangeThreshold
+	}
+
 	// Signing is a new feature, so if empty we set default values. Only applied
 	// for the effective configuration (applyDefaults), not for the separate
 	// global/custom views.


### PR DESCRIPTION
## Description

Previously, an unset (`nil`) `PixelChangeThreshold` could leave motion detection unexpectedly disabled or cause inconsistent behavior across config layers, while explicit `0` (intended UI disable) was treated the same as unset.

This PR:
- Sets a sensible default of `150` for `nil` values in the effective configuration only, preserving explicit `0` or other set values and allowing inheritance from global/custom configs.
- Upgrades the motion-disabled log to a **Warning** with clear guidance: explains `<=0` disables detection, notes the `150` default for unset, and instructs on enabling via config/env vars + agent restart.
- Fixes JSON formatting in MQTT payload by relocating inline comments.

**Improves reliability** by preventing accidental motion detection failures, **enhances observability/debuggability** for users/operators, and **cleans up code** for maintainability.