### PR TITLE
fix/apply-permissions-home-dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	ca-certificates curl ffmpeg libatomic1 libcap2-bin libstdc++6 && \
 	rm -rf /var/lib/apt/lists/* && \
 	groupadd --system kerberosio && \
-	useradd --system --gid kerberosio --groups video --create-home agent
+	useradd --system --gid kerberosio --groups video --create-home agent && \
+	chmod 0755 /home/agent
 
 #################################
 # Copy files from previous images


### PR DESCRIPTION
## Description

## Motivation

The agent’s home directory may be created with permissions that prevent required users or processes from traversing it, causing runtime access failures inside the container.

This change explicitly sets `/home/agent` to `0755`, ensuring predictable access while keeping write permissions restricted to the owner. This makes container behavior consistent across environments and avoids permission-related startup or file access issues.