### PR TITLE
feature/update-docs

### DIFF
--- a/README-RTSPS-TLS.md
+++ b/README-RTSPS-TLS.md
@@ -75,7 +75,7 @@ sequenceDiagram
   participant Trust as Go trust pool
   participant Camera as Camera RTSPS :9554
 
-  Agent->>Trust: Load trusted CAs from SSL_CERT_FILE and CA directories
+  Agent->>Trust: Load system roots and append AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE
   Agent->>Camera: Open TCP connection
   Agent->>Camera: Send TLS ClientHello
   Camera-->>Agent: Send TLS ServerHello and camera certificate
@@ -505,7 +505,8 @@ openssl s_client \
 On Unix, Go uses `SSL_CERT_FILE` instead of its default aggregate CA file, but it
 still scans default certificate directories such as `/etc/ssl/certs`. Setting
 `SSL_CERT_FILE` alone therefore does not remove CA certificates installed with
-`update-ca-certificates`.
+`update-ca-certificates`. `AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE` is appended
+after this system pool is loaded; it does not replace the system roots.
 
 Blank values do not select empty trust sources. Both `SSL_CERT_FILE=` and
 `SSL_CERT_DIR=` are treated as unset, so Go falls back to its default aggregate
@@ -517,6 +518,7 @@ directory path that contains no certificates:
 mkdir -p /tmp/empty-ca-dir
 SSL_CERT_FILE=/dev/null \
 SSL_CERT_DIR=/tmp/empty-ca-dir \
+AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE= \
 AGENT_CAPTURE_IPCAMERA_RTSPS_INSECURE=false \
 GOWORK=off \
 go run -tags moq . -action run -port 8080
@@ -553,8 +555,9 @@ openssl req \
   -keyout /tmp/unrelated-test-root.key \
   -out /tmp/unrelated-test-root.crt
 
-SSL_CERT_FILE=/tmp/unrelated-test-root.crt \
+SSL_CERT_FILE=/dev/null \
 SSL_CERT_DIR=/tmp/empty-ca-dir \
+AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE=/tmp/unrelated-test-root.crt \
 AGENT_CAPTURE_IPCAMERA_RTSPS_INSECURE=false \
 GOWORK=off \
 go run -tags moq . -action run -port 8080

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ AGENT_CAPTURE_IPCAMERA_SUB_RTSP='rtsps://username:password@camera.example:9554/?
 
 Certificate verification is enabled by default. The URL hostname or IP address must match the camera certificate SAN. On this Bosch firmware, RTSPS presents the certificate assigned to **HTTPS**; there is no separate SRTSP certificate usage. Leave **CBS client** assigned to the Bosch device certificate.
 
-For a private CA, mount a PEM trust bundle containing every CA certificate needed to build the camera certificate chain and set `SSL_CERT_FILE` to that file. This Bosch firmware presents only its leaf certificate, so include both the issuing intermediate and root certificates in the bundle. As a temporary fallback, `AGENT_CAPTURE_IPCAMERA_RTSPS_INSECURE=true` disables certificate verification for camera streams only.
+For a private CA, mount a PEM trust bundle containing every CA certificate needed to build the camera certificate chain and set `AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE` to its path inside the Agent. The bundle is appended to the system roots for camera RTSPS connections only. This Bosch firmware presents only its leaf certificate, so include both the issuing intermediate and root certificates in the bundle. As a temporary fallback, `AGENT_CAPTURE_IPCAMERA_RTSPS_INSECURE=true` disables certificate verification for camera streams only.
 
 See [RTSPS and TLS certificates](README-RTSPS-TLS.md) for the complete Bosch UI, private-CA, deployment, validation, and troubleshooting procedure.
 
@@ -225,6 +225,7 @@ See [RTSPS and TLS certificates](README-RTSPS-TLS.md) for the complete Bosch UI,
 | `AGENT_REGION_POLYGON`                      | A single polygon set for motion detection: "x1,y1;x2,y2;x3,y3;...                               | ""                             |
 | `AGENT_CAPTURE_IPCAMERA_RTSP`               | Full-HD RTSP or RTSPS endpoint for the target camera.                                           | ""                             |
 | `AGENT_CAPTURE_IPCAMERA_SUB_RTSP`           | RTSP or RTSPS sub-stream endpoint used for livestreaming (WebRTC).                              | ""                             |
+| `AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE`      | PEM CA bundle appended to the system roots for RTSPS camera certificate verification.           | ""                             |
 | `AGENT_CAPTURE_IPCAMERA_RTSPS_INSECURE`     | Disable RTSPS camera certificate verification; use only when a trusted CA cannot be installed.  | "false"                        |
 | `AGENT_CAPTURE_IPCAMERA_BASE_WIDTH`         | Force a specific width resolution for live view processing.                                     | ""                             |
 | `AGENT_CAPTURE_IPCAMERA_BASE_HEIGHT`        | Force a specific height resolution for live view processing.                                    | ""                             |


### PR DESCRIPTION
## Description

## Summary

Documents the new `AGENT_CAPTURE_IPCAMERA_RTSPS_CA_FILE` configuration for private CA verification.

## Motivation

The previous documentation instructed users to override `SSL_CERT_FILE`, which could unintentionally replace or obscure the system trust roots. This made it unclear how to add a private CA while retaining standard certificate trust.

## What changed

- Updated `README.md` with the new environment variable and configuration table entry.
- Clarified that the provided PEM bundle is appended to the system roots and applies only to camera RTSPS connections.
- Updated RTSPS/TLS diagrams, deployment instructions, and validation examples to reflect the new trust behavior.
- Documented that `SSL_CERT_FILE` and `SSL_CERT_DIR` do not need to be used for supplying the camera’s private CA.

These updates make private CA configuration more accurate, safer, and easier to follow.