### PR TITLE
fix/discard-failed-recordings

### DIFF
--- a/machinery/src/cloud/kerberos_vault.go
+++ b/machinery/src/cloud/kerberos_vault.go
@@ -35,8 +35,13 @@ func UploadKerberosVault(configuration *models.Configuration, fileName string) (
 	// This can happen when the file was already removed (e.g. cleanup, or an
 	// earlier successful upload). Skip it so the watcher drops the marker
 	// instead of retrying indefinitely.
-	if _, err := os.Stat("data/recordings/" + fileName); err != nil {
+	info, err := os.Stat("data/recordings/" + fileName)
+	if err != nil {
 		log.Log.Info("UploadKerberosVault: skipping " + fileName + ", file doesn't exist anymore")
+		return false, false, nil
+	}
+	if info.Size() == 0 {
+		log.Log.Warning("UploadKerberosVault: skipping " + fileName + ", recording is empty")
 		return false, false, nil
 	}
 

--- a/machinery/src/cloud/tus_client_test.go
+++ b/machinery/src/cloud/tus_client_test.go
@@ -264,6 +264,36 @@ func testVault(uri string) models.KStorage {
 	}
 }
 
+func TestUploadKerberosVaultSkipsEmptyRecording(t *testing.T) {
+	fileName := "1787015373_3-654_office-camera17_0-0-0-0_-1_1960.mp4"
+	withRecording(t, fileName, nil)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	vault := testVault(server.URL)
+	configuration := &models.Configuration{Config: models.Config{
+		Key:               "device-key",
+		KStorage:          &vault,
+		KStorageSecondary: &models.KStorage{},
+	}}
+
+	uploaded, configured, err := UploadKerberosVault(configuration, fileName)
+	if err != nil {
+		t.Fatalf("UploadKerberosVault() error = %v", err)
+	}
+	if uploaded || configured {
+		t.Fatalf("UploadKerberosVault() uploaded/configured = %v/%v, want false/false", uploaded, configured)
+	}
+	if requestCount != 0 {
+		t.Fatalf("Vault received %d requests, want 0", requestCount)
+	}
+}
+
 func TestUploadVaultResumable_HappyPath(t *testing.T) {
 	srv := newFakeTus()
 	ts := httptest.NewServer(srv)


### PR DESCRIPTION
## Description

## Motivation

Failed recordings can leave behind empty files that the watcher repeatedly attempts to upload, causing unnecessary retries and noise.

## What changed

- Skip recordings with a file size of zero before starting an upload.
- Log a warning when an empty recording is discarded.
- Add a test verifying that empty recordings do not trigger vault requests or upload retries.

This prevents invalid recordings from reaching storage and allows the watcher to clean up their markers instead of retrying indefinitely.