### PR TITLE
fix/build-error-yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,8 @@ RUN apk update && apk upgrade --available && sync
 
 RUN mkdir -p /go/src/github.com/kerberos-io/agent/machinery/www
 COPY ui /go/src/github.com/kerberos-io/agent/ui
-RUN cd /go/src/github.com/kerberos-io/agent/ui && rm -rf yarn.lock && yarn config set network-timeout 300000 && \
-	yarn && yarn build
+RUN cd /go/src/github.com/kerberos-io/agent/ui && yarn config set network-timeout 300000 && \
+	yarn --frozen-lockfile && yarn build
 
 ####################################
 # Let's create a /dist folder containing just the files necessary for runtime.


### PR DESCRIPTION
Stop deleting yarn.lock before install and instead run yarn with --frozen-lockfile to ensure reproducible UI builds in Docker.